### PR TITLE
add stateMutability to FUNCTION_ABI_ENTRY

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1777,6 +1777,12 @@
                     "event"
                 ]
             },
+            "STATE_MUTABILITY_TYPE": {
+                "type": "string",
+                "enum": [
+                    "view"
+                ]
+            },
             "FUNCTION_ABI_TYPE": {
                 "type": "string",
                 "enum": [
@@ -1863,6 +1869,12 @@
                         "description": "The function name",
                         "type": "string"
                     },
+                    "stateMutability": {
+                        "description": "specifies when a function is view-only",
+                        "schema": {
+                          "$ref": "#/components/schemas/STATE_MUTABILITY_TYPE"
+                        }
+                    },
                     "inputs": {
                         "type": "array",
                         "items": {
@@ -1875,7 +1887,13 @@
                             "$ref": "#/components/schemas/TYPED_PARAMETER"
                         }
                     }
-                }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "inputs",
+                  "outputs"
+                ]
             },
             "TYPED_PARAMETER": {
                 "type": "object",


### PR DESCRIPTION
The FUNCTION_ABI_ENTRY that are generated by the compiler and pushed to starknet seems to have a `stateMutability` property set to `view` when the function is in view mode. I propose to add it to the spec.