### PR TITLE
Fix DEPLOY_ACCOUNT_TXN reference

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1138,7 +1138,7 @@
                         "$ref": "#/components/schemas/DEPLOY_TXN"
                     },
                     {
-                        "ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+                        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
                     }
                 ]
             },


### PR DESCRIPTION
Add omitted `$` to `"ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"`.

Without it, `DEPLOY_ACCOUNT_TXN` doesn't show up in the OpenRPC playground.