### PR TITLE
Fix typos and structure errors

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -970,29 +970,32 @@
                 }
             },
             "BLOCK_HEADER": {
-                "block_hash": {
-                    "$ref": "#/components/schemas/BLOCK_HASH"
-                },
-                "parent_hash": {
-                    "description": "The hash of this block's parent",
-                    "$ref": "#/components/schemas/BLOCK_HASH"
-                },
-                "block_number": {
-                    "description": "The block number (its height)",
-                    "$ref": "#/components/schemas/BLOCK_NUMBER"
-                },
-                "new_root": {
-                    "description": "The new global state root",
-                    "$ref": "#/components/schemas/FELT"
-                },
-                "timestamp": {
-                    "description": "The time in which the block was created, encoded in Unix time",
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "sequencer_address": {
-                    "description": "The StarkNet identity of the sequencer submitting this block",
-                    "$ref": "#/components/schemas/FELT"
+                "type":"object",
+                "properties": {
+                    "block_hash": {
+                        "$ref": "#/components/schemas/BLOCK_HASH"
+                    },
+                    "parent_hash": {
+                        "description": "The hash of this block's parent",
+                        "$ref": "#/components/schemas/BLOCK_HASH"
+                    },
+                    "block_number": {
+                        "description": "The block number (its height)",
+                        "$ref": "#/components/schemas/BLOCK_NUMBER"
+                    },
+                    "new_root": {
+                        "description": "The new global state root",
+                        "$ref": "#/components/schemas/FELT"
+                    },
+                    "timestamp": {
+                        "description": "The time in which the block was created, encoded in Unix time",
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "sequencer_address": {
+                        "description": "The StarkNet identity of the sequencer submitting this block",
+                        "$ref": "#/components/schemas/FELT"
+                    }
                 }
             },
             "BLOCK_WITH_TX_HASHES": {
@@ -1018,8 +1021,11 @@
                 "title": "The block object",
                 "allOf": [
                     {
-                        "status": {
-                            "$ref": "#/components/schemas/BLOCK_STATUS"
+                        "type": "object",
+                        "properties": {
+                            "status": {
+                                "$ref": "#/components/schemas/BLOCK_STATUS"
+                            }
                         }
                     },
                     {
@@ -1138,7 +1144,7 @@
                         "$ref": "#/components/schemas/DEPLOY_TXN"
                     },
                     {
-                        "ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+                        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
                     }
                 ]
             },
@@ -1238,9 +1244,7 @@
                         "properties": {
                             "contract_class": {
                                 "description": "The class to be declared",
-                                "schema": {
-                                    "$ref": "#/components/schemas/CONTRACT_CLASS"
-                                }
+                                "$ref": "#/components/schemas/CONTRACT_CLASS"
                             },
                             "sender_address": {
                                 "description": "The address of the account contract sending the declaration transaction",
@@ -1324,9 +1328,7 @@
                         "properties": {
                             "contract_class": {
                                 "description": "The class of the contract that will be deployed",
-                                "schema": {
-                                    "$ref": "#/components/schemas/CONTRACT_CLASS"
-                                }
+                                "$ref": "#/components/schemas/CONTRACT_CLASS"
                             }
                         }
                     },
@@ -1695,26 +1697,18 @@
                         "type": "object",
                         "properties": {
                             "CONSTRUCTOR": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
-                                }
+                                "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
                             },
                             "EXTERNAL": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
-                                }
+                                "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
                             },
                             "L1_HANDLER": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
-                                }
+                                "$ref": "#/components/schemas/CONTRACT_ENTRY_POINT_LIST"
                             }
                         }
                     },
                     "abi": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CONTRACT_ABI"
-                        }
+                        "$ref": "#/components/schemas/CONTRACT_ABI"
                     }
                 },
                 "required": [
@@ -1733,15 +1727,11 @@
                 "properties": {
                     "offset": {
                         "description": "The offset of the entry point in the program",
-                        "schema": {
-                            "$ref": "#/components/schemas/NUM_AS_HEX"
-                        }
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "selector": {
                         "description": "A unique identifier of the entry point (function) in the program",
-                        "schema": {
-                            "$ref": "#/components/schemas/FELT"
-                        }
+                        "$ref": "#/components/schemas/FELT"
                     }
                 }
             },
@@ -1752,7 +1742,6 @@
                 }
             },
             "CONTRACT_ABI_ENTRY": {
-                "type": "object",
                 "oneOf": [
                     {
                         "$ref": "#/components/schemas/FUNCTION_ABI_ENTRY"
@@ -1786,11 +1775,10 @@
                 ]
             },
             "STRUCT_ABI_ENTRY": {
+                "type": "object",
                 "properties": {
                     "type": {
-                        "schema": {
-                            "$ref": "#/components/schemas/STRUCT_ABI_TYPE"
-                        }
+                        "$ref": "#/components/schemas/STRUCT_ABI_TYPE"
                     },
                     "name": {
                         "description": "The struct name",
@@ -1809,7 +1797,6 @@
                 }
             },
             "STRUCT_MEMBER": {
-                "type": "object",
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/TYPED_PARAMETER"
@@ -1829,9 +1816,7 @@
                 "type": "object",
                 "properties": {
                     "type": {
-                        "schema": {
-                            "$ref": "#/components/schemas/EVENT_ABI_TYPE"
-                        }
+                        "$ref": "#/components/schemas/EVENT_ABI_TYPE"
                     },
                     "name": {
                         "description": "The event name",
@@ -1855,9 +1840,7 @@
                 "type": "object",
                 "properties": {
                     "type": {
-                        "schema": {
-                            "$ref": "#/components/schemas/FUNCTION_ABI_TYPE"
-                        }
+                        "$ref": "#/components/schemas/FUNCTION_ABI_TYPE"
                     },
                     "name": {
                         "description": "The function name",
@@ -1895,21 +1878,15 @@
                 "properties": {
                     "gas_consumed": {
                         "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
-                        "schema": {
-                            "$ref": "#/components/schemas/NUM_AS_HEX"
-                        }
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {
                         "description": "The gas price (in gwei) that was used in the cost estimation",
-                        "schema": {
-                            "$ref": "#/components/schemas/NUM_AS_HEX"
-                        }
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "overall_fee": {
                         "description": "The estimated fee for the transaction (in gwei), product of gas_consumed and gas_price",
-                        "schema": {
-                            "$ref": "#/components/schemas/NUM_AS_HEX"
-                        }
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     }
                 }
             }

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -41,6 +41,7 @@
             "params": [
                 {
                     "name": "declare_transaction",
+                    "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
                     }
@@ -76,6 +77,7 @@
                 {
                     "name": "deploy_transaction",
                     "description": "The deploy transaction",
+                    "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/BROADCASTED_DEPLOY_TXN"
                     }
@@ -111,6 +113,7 @@
                 {
                     "name": "deploy_account_transaction",
                     "description": "The deploy account transaction",
+                    "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
                     }


### PR DESCRIPTION
I'm trying to develop a codegen tool for automatically generating the JSON-RPC client code for `starknet-rs`. However, when parsing the specs, I encountered typos and structural inconsistencies that result in parsing errors. I'm submitting this PR for fixing them:

- Incorrectly laying out the fields directly instead of specifying `type` as `object` and putting them inside `properties`
- There's a typo of `ref` instead of `$ref`
- Incorrectly wrapping `$ref` inside another `schema` object when it should be laid flat
- Forgetting to specify `type` as `object` when `properties` is used
- Incorrectly specifying `type` as `object` when `oneOf` or `allOf` is used
- Forgetting to mark param as `required` in write APIs

Otherwise this PR makes no change to the actual specification.