### PR TITLE
feat: add CLASS_ALREADY_DECLARED error

### DIFF
--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -67,6 +67,9 @@
             "errors": [
                 {
                     "$ref": "#/components/errors/INVALID_CONTRACT_CLASS"
+                },
+                {
+                    "$ref": "#/components/errors/CLASS_ALREADY_DECLARED"
                 }
             ]
         },
@@ -147,6 +150,10 @@
             },
             "CLASS_HASH_NOT_FOUND": {
                 "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
+            },
+            "CLASS_ALREADY_DECLARED": {
+                "code": 51,
+                "message": "Class already declared"
             }
         }
     }


### PR DESCRIPTION
Starknet v0.11.0 added a new error code `StarknetErrorCode.CLASS_ALREADY_DECLARED` on the sequencer gateway, as the sequencer does not allow declaring the same Cairo 1 classes multiple times (still allowed for Cairo 0 classes though). With the current specs here there's no way to represent that error properly.

This PR fixes that by adding a new possible error for the `starknet_addDeclareTransaction` method called `CLASS_ALREADY_DECLARED`.