### PR TITLE
updated the outdated url in the fee_estimate component

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2301,7 +2301,7 @@
                 "type": "object",
                 "properties": {
                     "gas_consumed": {
-                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/docs/Fees/fee-mechanism for more info)",
+                        "description": "The Ethereum gas cost of the transaction (see https://docs.starknet.io/documentation/architecture_and_concepts/Fees/fee-mechanism/ for more info)",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "gas_price": {


### PR DESCRIPTION
The url in the `FEE ESTIMATE` component for the `fee-mechanism` was an old URL which does not work now. 

Updated it to be the correct one!

For context:

[Old URL](https://docs.starknet.io/docs/Fees/fee-mechanism) | [New URL](https://docs.starknet.io/documentation/architecture_and_concepts/Fees/fee-mechanism/)