### PR TITLE
fix: missing required field `compiled_class_hash`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1692,7 +1692,8 @@
                         "required": [
                             "type",
                             "contract_class",
-                            "sender_address"
+                            "sender_address",
+                            "compiled_class_hash"
                         ]
                     }
                 ]


### PR DESCRIPTION
Pretty sure this field is not optional. The current specs does not specify it's required.