### PR TITLE
fix: missing required field in `PENDING_COMMON_RECEIPT_PROPERTIES`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2238,6 +2238,7 @@
                 "required": [
                     "transaction_hash",
                     "actual_fee",
+                    "type",
                     "messages_sent",
                     "events"
                 ]


### PR DESCRIPTION
Field `type` should be required too for `PENDING_COMMON_RECEIPT_PROPERTIES`.