### PR TITLE
fix: missing `type` for `BROADCASTED_DECLARE_TXN_V1`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1638,7 +1638,7 @@
                     },
                     {
                         "type": "object",
-                        "title": "Event emitter",
+                        "title": "Declare v1",
                         "properties": {
                             "type": {
                                 "title": "Declare",


### PR DESCRIPTION
This field is only defined for v2 but not v1.