### PR TITLE
fix: `EVENT_FILTER` fields should be optional

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -886,12 +886,7 @@
                         }
                     }
                 },
-                "required": [
-                    "from_block",
-                    "to_block",
-                    "address",
-                    "keys"
-                ]
+                "required": []
             },
             "BLOCK_ID": {
                 "title": "Block id",


### PR DESCRIPTION
Pretty sure those fields are optional. The current `pathfinder` implementation for `0.3` also treats them as optional:

https://github.com/eqlabs/pathfinder/blob/c802d9aea508fbaad0b80ba11f60e18e4c75cb3e/crates/rpc/src/v03/method/get_events.rs#L51_L67

I believe this is an error from #84.