### PR TITLE
fix: missing stateMutability in `FUNCTION_ABI_ENTRY`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2656,6 +2656,13 @@
                     "data"
                 ]
             },
+            "FUNCTION_STATE_MUTABILITY": {
+                "title": "Function state mutability type",
+                "type": "string",
+                "enum": [
+                    "view"
+                ]
+            },
             "FUNCTION_ABI_ENTRY": {
                 "title": "Function ABI entry",
                 "type": "object",
@@ -2682,6 +2689,10 @@
                         "items": {
                             "$ref": "#/components/schemas/TYPED_PARAMETER"
                         }
+                    },
+                    "stateMutability": {
+                        "title": "Function state mutability",
+                        "$ref": "#/components/schemas/FUNCTION_STATE_MUTABILITY"
                     }
                 },
                 "required": [


### PR DESCRIPTION
Supersedes #60 as that PR is now updated.

We should add this field as `pathfinder` and `starknet-rs` have been forced to deviate from the specs for this anyways:

https://github.com/eqlabs/pathfinder/blob/c802d9aea508fbaad0b80ba11f60e18e4c75cb3e/crates/rpc/src/v02/types/class.rs#L378_L384