### PR TITLE
Add Missing Statuses

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3004,7 +3004,8 @@
                 "type": "string",
                 "enum": [
                     "ACCEPTED_ON_L2",
-                    "ACCEPTED_ON_L1"
+                    "ACCEPTED_ON_L1",
+                    "RECEIVED"
                 ],
                 "description": "The finality status of the transaction"
             },
@@ -3013,7 +3014,8 @@
                 "type": "string",
                 "enum": [
                     "SUCCEEDED",
-                    "REVERTED"
+                    "REVERTED",
+                    "REJECTED"
                 ],
                 "description": "The execution status of the transaction"
             },


### PR DESCRIPTION
Based off of https://community.starknet.io/t/efficient-utilization-of-sequencer-capacity-in-starknet-v0-12-1/95607 there should be a `RECEIVED` finality status and a `REJECTED` execution status. 

