### PR TITLE
Remove v3 transcations

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1626,10 +1626,6 @@
                     {
                         "title": "Declare transaction V2",
                         "$ref": "#/components/schemas/DECLARE_TXN_V2"
-                    },
-                    {
-                        "title": "Declare transaction V3",
-                        "$ref": "#/components/schemas/DECLARE_TXN_V3"
                     }
                 ]
             },
@@ -1811,72 +1807,6 @@
                     }
                 ]
             },
-            "DECLARE_TXN_V3": {
-                "title": "Declare Transaction V3",
-                "description": "Declare Contract Transaction V3",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "title": "Declare txn v3",
-                        "properties": {
-                            "type": {
-                                "title": "Declare",
-                                "type": "string",
-                                "enum": [
-                                    "DECLARE"
-                                ]
-                            },
-                            "sender_address": {
-                                "title": "Sender address",
-                                "description": "The address of the account contract sending the declaration transaction",
-                                "$ref": "#/components/schemas/ADDRESS"
-                            },
-                            "compiled_class_hash": {
-                                "title": "Compiled class hash",
-                                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "version": {
-                                "title": "Version",
-                                "description": "Version of the transaction scheme",
-                                "type": "string",
-                                "enum": [
-                                    "0x3"
-                                ]
-                            },
-                            "signature": {
-                                "title": "Signature",
-                                "$ref": "#/components/schemas/SIGNATURE"
-                            },
-                            "nonce": {
-                                "title": "Nonce",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "class_hash": {
-                                "title": "Class hash",
-                                "description": "The hash of the declared class",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "l1_gas": {
-                                "title": "L1 Gas",
-                                "description": "The max amount and max price per unit of L1 gas used in this tx",
-                                "$ref": "#/components/schemas/RESOURCE_LIMITS"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "sender_address",
-                            "compiled_class_hash",
-                            "max_fee",
-                            "version",
-                            "signature",
-                            "nonce",
-                            "class_hash",
-                            "l1_gas"
-                        ]
-                    }
-                ]
-            },
             "BROADCASTED_TXN": {
                 "oneOf": [
                     {
@@ -1917,10 +1847,6 @@
                     {
                         "title": "Broadcasted declare transaction V2",
                         "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V2"
-                    },
-                    {
-                        "title": "Broadcasted declare transaction V3",
-                        "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
                     }
                 ]
             },
@@ -2030,69 +1956,6 @@
                     }
                 ]
             },
-            "BROADCASTED_DECLARE_TXN_V3": {
-                "title": "Broadcasted declare Transaction V3",
-                "description": "Broadcasted declare Contract Transaction V3",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "title": "Declare txn v3",
-                        "properties": {
-                            "type": {
-                                "title": "Declare",
-                                "type": "string",
-                                "enum": [
-                                    "DECLARE"
-                                ]
-                            },
-                            "sender_address": {
-                                "title": "Sender address",
-                                "description": "The address of the account contract sending the declaration transaction",
-                                "$ref": "#/components/schemas/ADDRESS"
-                            },
-                            "compiled_class_hash": {
-                                "title": "Compiled class hash",
-                                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "version": {
-                                "title": "Version",
-                                "description": "Version of the transaction scheme",
-                                "$ref": "#/components/schemas/NUM_AS_HEX"
-                            },
-                            "signature": {
-                                "title": "Signature",
-                                "$ref": "#/components/schemas/SIGNATURE"
-                            },
-                            "nonce": {
-                                "title": "Nonce",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "contract_class": {
-                                "title": "Contract class",
-                                "description": "The class to be declared",
-                                "$ref": "#/components/schemas/CONTRACT_CLASS"
-                            },
-                            "l1_gas": {
-                                "title": "L1 Gas",
-                                "description": "The max amount and max price per unit of L1 gas used in this tx",
-                                "$ref": "#/components/schemas/RESOURCE_LIMITS"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "sender_address",
-                            "compiled_class_hash",
-                            "max_fee",
-                            "version",
-                            "signature",
-                            "nonce",
-                            "contract_class",
-                            "l1_gas"
-                        ]
-                    }
-                ]
-            },
             "DEPLOY_ACCOUNT_TXN": {
                 "title": "Deploy account transaction",
                 "description": "deploys a new account contract",
@@ -2100,10 +1963,6 @@
                     {
                         "title": "Deploy account V1",
                         "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V1"
-                    },
-                    {
-                        "title": "Deploy account V3",
-                        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
                     }
                 ]
             },
@@ -2164,66 +2023,6 @@
                     "contract_address_salt",
                     "constructor_calldata",
                     "class_hash"
-                ]
-            },
-            "DEPLOY_ACCOUNT_TXN_V3": {
-                "title": "Deploy account transaction",
-                "description": "Deploys an account contract, charges fee from the pre-funded account addresses",
-                "properties": {
-                    "type": {
-                        "title": "Deploy account",
-                        "type": "string",
-                        "enum": [
-                            "DEPLOY_ACCOUNT"
-                        ]
-                    },
-                    "version": {
-                        "title": "Version",
-                        "description": "Version of the transaction scheme",
-                        "$ref": "#/components/schemas/NUM_AS_HEX"
-                    },
-                    "signature": {
-                        "title": "Signature",
-                        "$ref": "#/components/schemas/SIGNATURE"
-                    },
-                    "nonce": {
-                        "title": "Nonce",
-                        "$ref": "#/components/schemas/FELT"
-                    },
-                    "contract_address_salt": {
-                        "title": "Contract address salt",
-                        "description": "The salt for the address of the deployed contract",
-                        "$ref": "#/components/schemas/FELT"
-                    },
-                    "constructor_calldata": {
-                        "type": "array",
-                        "description": "The parameters passed to the constructor",
-                        "title": "Constructor calldata",
-                        "items": {
-                            "$ref": "#/components/schemas/FELT"
-                        }
-                    },
-                    "class_hash": {
-                        "title": "Class hash",
-                        "description": "The hash of the deployed contract's class",
-                        "$ref": "#/components/schemas/FELT"
-                    },
-                    "l1_gas": {
-                        "title": "L1 Gas",
-                        "description": "The max amount and max price per unit of L1 gas used in this tx",
-                        "$ref": "#/components/schemas/RESOURCE_LIMITS"
-                    }
-                },
-                "required": [
-                    "max_fee",
-                    "version",
-                    "signature",
-                    "nonce",
-                    "type",
-                    "contract_address_salt",
-                    "constructor_calldata",
-                    "class_hash",
-                    "l1_gas"
                 ]
             },
             "DEPLOY_TXN": {
@@ -2387,64 +2186,6 @@
                     }
                 ]
             },
-            "INVOKE_TXN_V3": {
-                "title": "Invoke transaction V3",
-                "description": "initiates a transaction from a given account",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "title": "Type",
-                                "type": "string",
-                                "enum": [
-                                    "INVOKE"
-                                ]
-                            },
-                            "sender_address": {
-                                "title": "sender address",
-                                "$ref": "#/components/schemas/ADDRESS"
-                            },
-                            "calldata": {
-                                "type": "array",
-                                "title": "calldata",
-                                "description": "The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)",
-                                "items": {
-                                    "$ref": "#/components/schemas/FELT"
-                                }
-                            },
-                            "version": {
-                                "title": "Version",
-                                "description": "Version of the transaction scheme",
-                                "$ref": "#/components/schemas/NUM_AS_HEX"
-                            },
-                            "signature": {
-                                "title": "Signature",
-                                "$ref": "#/components/schemas/SIGNATURE"
-                            },
-                            "nonce": {
-                                "title": "Nonce",
-                                "$ref": "#/components/schemas/FELT"
-                            },
-                            "l1_gas": {
-                                "title": "L1 Gas",
-                                "description": "The max amount and max price per unit of L1 gas used in this tx",
-                                "$ref": "#/components/schemas/RESOURCE_LIMITS"
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "sender_address",
-                            "calldata",
-                            "max_fee",
-                            "version",
-                            "signature",
-                            "nonce",
-                            "l1_gas"
-                        ]
-                    }
-                ]
-            },
             "INVOKE_TXN": {
                 "title": "Invoke transaction",
                 "description": "Initiate a transaction from an account",
@@ -2456,10 +2197,6 @@
                     {
                         "title": "Invoke transaction V1",
                         "$ref": "#/components/schemas/INVOKE_TXN_V1"
-                    },
-                    {
-                        "title": "Invoke transaction V3",
-                        "$ref": "#/components/schemas/INVOKE_TXN_V3"
                     }
                 ]
             },


### PR DESCRIPTION
v0.5.0 will focus solely on the feeder gateway deprecation and aligning capabilities with the RPC, v3 transactions will be in the next version