### PR TITLE
add string data to CONTRACT_ERROR

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3596,7 +3596,19 @@
             },
             "CONTRACT_ERROR": {
                 "code": 40,
-                "message": "Contract error"
+                "message": "Contract error",
+                "data": {
+                    "type": "object",
+                    "description": "More data about the execution failure",
+                    "properties": {
+                        "revert_error": {
+                            "title": "revert error",
+                            "description": "a string encoding the execution trace up to the point of failure",
+                            "type": "string"
+                        }
+                    },
+                    "required": "revert_error"
+                }
             }
         }
     }


### PR DESCRIPTION
allows propagating errors from the blockifier or starknet_in_rust from the RPC