### PR TITLE
fix: missing offset for estimateFee

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1894,6 +1894,7 @@
                             "version": {
                                 "title": "Version",
                                 "description": "Version of the transaction scheme",
+                                "$comment": "For estimateFee, add 2**128 to the version",
                                 "$ref": "#/components/schemas/NUM_AS_HEX"
                             },
                             "signature": {
@@ -1955,6 +1956,8 @@
                             "version": {
                                 "title": "Version",
                                 "description": "Version of the transaction scheme",
+                                "$comment": "For estimateFee, add 2**128 to the version",
+
                                 "$ref": "#/components/schemas/NUM_AS_HEX"
                             },
                             "signature": {
@@ -2013,6 +2016,7 @@
                     "version": {
                         "title": "Version",
                         "description": "Version of the transaction scheme",
+                        "$comment": "For estimateFee, add 2**128 to the version",
                         "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "signature": {
@@ -2191,6 +2195,7 @@
                             "version": {
                                 "title": "Version",
                                 "description": "Version of the transaction scheme",
+                                "$comment": "For estimateFee, add 2**128 to the version",
                                 "$ref": "#/components/schemas/NUM_AS_HEX"
                             },
                             "signature": {


### PR DESCRIPTION
Starkware requested a long time ago  to Starknet.js team to be compliant with :
https://github.com/starkware-libs/cairo-lang/blob/9e6e0e96d208608d98635ccfad5b26285c4936e1/src/starkware/starknet/definitions/constants.py#L63-L65

If you estimate the fee using the normal version then anyone can replay the estimate fee transaction as a proper transaction even though the actual user didn’t intend to.
To add an offset  (2^128 in this case) to the version in case of estimateFee solves this security issue.

It has been implemented in Starknet.js a long time ago : https://github.com/0xs34n/starknet.js/blob/ce57fdcaba61a8ef2382acc9233a9aac2ac8589a/src/utils/hash.ts#L30-34

Unfortunately, it has never been implemented in the spec.
This PR proposes to add comments in the spec on this subject.


