### PR TITLE
RPC 0.6 Fix declare txn v1 version

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1735,7 +1735,7 @@
                                 "description": "Version of the transaction scheme",
                                 "type": "string",
                                 "enum": [
-                                    "0x0",
+                                    "0x1",
                                     "0x100000000000000000000000000000001"
                                 ]
                             },

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3380,7 +3380,7 @@
                     "offset": {
                         "title": "Offset",
                         "description": "The offset of the entry point in the program",
-                        "type": "#/components/schemas/NUM_AS_HEX"
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
                     },
                     "selector": {
                         "title": "Selector",

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2963,7 +2963,7 @@
                     "offset": {
                         "title": "Offset",
                         "description": "The offset of the entry point in the program",
-                        "$ref": "#/components/schemas/NUM_AS_HEX"
+                        "type": "integer"
                     },
                     "selector": {
                         "title": "Selector",

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3380,7 +3380,7 @@
                     "offset": {
                         "title": "Offset",
                         "description": "The offset of the entry point in the program",
-                        "type": "integer"
+                        "type": "#/components/schemas/NUM_AS_HEX"
                     },
                     "selector": {
                         "title": "Selector",


### PR DESCRIPTION
This looks like a mistake it should be "0x1" for v1 transaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/170)
<!-- Reviewable:end -->
