### PR TITLE
Change StarkNet to Starknet in JSON RPC

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2,7 +2,7 @@
     "openrpc": "1.0.0-rc1",
     "info": {
         "version": "0.6.0",
-        "title": "StarkNet Node API",
+        "title": "Starknet Node API",
         "license": {}
     },
     "servers": [],
@@ -560,7 +560,7 @@
         },
         {
             "name": "starknet_call",
-            "summary": "call a starknet function without creating a StarkNet transaction",
+            "summary": "call a starknet function without creating a Starknet transaction",
             "description": "Calls a function in a contract and returns the return value.  Using this call will not create a transaction; hence, will not change the state",
             "params": [
                 {
@@ -611,7 +611,7 @@
         },
         {
             "name": "starknet_estimateFee",
-            "summary": "estimate the fee for of StarkNet transactions",
+            "summary": "estimate the fee for of Starknet transactions",
             "description": "estimates the resources required by transactions when applyed on a given state",
             "params": [
                 {
@@ -764,7 +764,7 @@
         },
         {
             "name": "starknet_chainId",
-            "summary": "Return the currently configured StarkNet chain id",
+            "summary": "Return the currently configured Starknet chain id",
             "params": [],
             "result": {
                 "name": "result",
@@ -974,7 +974,7 @@
             },
             "EVENT": {
                 "title": "Event",
-                "description": "A StarkNet event",
+                "description": "A Starknet event",
                 "allOf": [
                     {
                         "title": "Event emitter",
@@ -1163,7 +1163,7 @@
             },
             "CHAIN_ID": {
                 "title": "Chain id",
-                "description": "StarkNet chain id, given in hex representation.",
+                "description": "Starknet chain id, given in hex representation.",
                 "type": "string",
                 "pattern": "^0x[a-fA-F0-9]+$"
             },
@@ -1339,7 +1339,7 @@
             },
             "TXN_HASH": {
                 "$ref": "#/components/schemas/FELT",
-                "description": "The transaction hash, as assigned in StarkNet",
+                "description": "The transaction hash, as assigned in Starknet",
                 "title": "Transaction hash"
             },
             "FELT": {
@@ -1443,7 +1443,7 @@
                     },
                     "sequencer_address": {
                         "title": "Sequencer address",
-                        "description": "The StarkNet identity of the sequencer submitting this block",
+                        "description": "The Starknet identity of the sequencer submitting this block",
                         "$ref": "#/components/schemas/FELT"
                     },
                     "l1_gas_price": {
@@ -1485,7 +1485,7 @@
                     },
                     "sequencer_address": {
                         "title": "Sequencer address",
-                        "description": "The StarkNet identity of the sequencer submitting this block",
+                        "description": "The Starknet identity of the sequencer submitting this block",
                         "$ref": "#/components/schemas/FELT"
                     },
                     "l1_gas_price": {
@@ -3384,7 +3384,7 @@
             },
             "DEPRECATED_CONTRACT_CLASS": {
                 "title": "Deprecated contract class",
-                "description": "The definition of a StarkNet contract class",
+                "description": "The definition of a Starknet contract class",
                 "type": "object",
                 "properties": {
                     "program": {


### PR DESCRIPTION
The correct casing is *Starknet*, not *StarkNet*. It's important that the official spec contain the correct casing.