### PR TITLE
refactor BLOCK_BODY_WITH_RECEIPTS

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1418,25 +1418,21 @@
                         "description": "The transactions in this block",
                         "type": "array",
                         "items": {
-                            "title": "transactions in block",
                             "type": "object",
-                            "allOf": [
-                                {
+                            "title": "transaction and receipt",
+                            "properties": {
+                                "transaction": {
                                     "title": "transaction",
                                     "$ref": "#/components/schemas/TXN"
                                 },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "receipt": {
-                                            "title": "receipt",
-                                            "$ref": "#/components/schemas/TXN_RECEIPT"
-                                        }
-                                    },
-                                    "required": [
-                                        "receipt"
-                                    ]
+                                "receipt": {
+                                    "title": "receipt",
+                                    "$ref": "#/components/schemas/TXN_RECEIPT_IN_BLOCK"
                                 }
+                            },
+                            "required": [
+                                "transaction",
+                                "receipt"
                             ]
                         }
                     }
@@ -3207,6 +3203,10 @@
                         "$ref": "#/components/schemas/PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT"
                     }
                 ]
+            },
+            "TXN_RECEIPT_IN_BLOCK": {
+                "title": "receipt in block",
+                "$ref": "#/components/schemas/PENDING_TXN_RECEIPT"
             },
             "PENDING_COMMON_RECEIPT_PROPERTIES": {
                 "title": "Pending common receipt properties",

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2852,6 +2852,7 @@
                     },
                     "finality_status": {
                         "title": "Finality status",
+                        "description": "finality status of the tx, which is ACCEPTED_ON_L2 when included in a pending receipt, and can be ACCEPTED_ON_L1 when part of a getBlockWithReceipts response",
                         "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
                     },
                     "block_hash": {
@@ -3246,11 +3247,7 @@
                     },
                     "finality_status": {
                         "title": "Finality status",
-                        "type": "string",
-                        "enum": [
-                            "ACCEPTED_ON_L2"
-                        ],
-                        "description": "The finality status of the transaction"
+                        "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
                     },
                     "execution_status": {
                         "title": "Execution status",


### PR DESCRIPTION
Removes the redundant block-related fields from the receipt, when appearing in a block with receipts request. To this end we're using the same objects that represent a transaction receipt in the pending block.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/191)
<!-- Reviewable:end -->
