### PR TITLE
fix: missing/invalid `required` field

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1194,7 +1194,11 @@
                                     "description": "The Cairo assembly hash corresponding to the declared class",
                                     "$ref": "#/components/schemas/FELT"
                                 }
-                            }
+                            },
+                            "required": [
+                                "class_hash",
+                                "compiled_class_hash"
+                            ]
                         }
                     },
                     "deployed_contracts": {
@@ -1223,7 +1227,11 @@
                                     "description": "The new class hash",
                                     "$ref": "#/components/schemas/FELT"
                                 }
-                            }
+                            },
+                            "required": [
+                                "contract_address",
+                                "class_hash"
+                            ]
                         }
                     },
                     "nonces": {
@@ -1244,7 +1252,11 @@
                                     "description": "The nonce for the given address at the end of the block",
                                     "$ref": "#/components/schemas/FELT"
                                 }
-                            }
+                            },
+                            "required": [
+                                "contract_address",
+                                "nonce"
+                            ]
                         }
                     }
                 },
@@ -1737,6 +1749,10 @@
                                     "description": "The new value applied to the given address",
                                     "$ref": "#/components/schemas/FELT"
                                 }
+                            },
+                            "required": {
+                                "key",
+                                "value"
                             }
                         }
                     }
@@ -3131,7 +3147,8 @@
                                 "$ref": "#/components/schemas/BLOCK_NUMBER",
                                 "description": "If this field is missing, it means the receipt belongs to the pending block"
                             }
-                        }
+                        },
+                        "required": []
                     }
                 ]
             },
@@ -3374,7 +3391,12 @@
                                     "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
                                 }
                             }
-                        }
+                        },
+                        "required": [
+                            "CONSTRUCTOR",
+                            "EXTERNAL",
+                            "L1_HANDLER"
+                        ]
                     },
                     "abi": {
                         "title": "Contract ABI",
@@ -3522,7 +3544,10 @@
                                 "description": "offset of this property within the struct",
                                 "type": "integer"
                             }
-                        }
+                        },
+                        "required": [
+                            "offset"
+                        ]
                     }
                 ]
             },
@@ -3958,7 +3983,9 @@
                             "type": "string"
                         }
                     },
-                    "required": "revert_error"
+                    "required": [
+                        "revert_error"
+                    ]
                 }
             },
             "TRANSACTION_EXECUTION_ERROR": {

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -90,7 +90,11 @@
                                     "title": "the transaction's resources and fee",
                                     "$ref": "#/components/schemas/FEE_ESTIMATE"
                                 }
-                            }
+                            },
+                            "required": [
+                                "transaction_trace",
+                                "fee_estimation"
+                            ]
                         }
                     }
                 }
@@ -133,7 +137,11 @@
                             "trace_root": {
                                 "$ref": "#/components/schemas/TRANSACTION_TRACE"
                             }
-                        }
+                        },
+                        "required": [
+                            "transaction_hash",
+                            "trace_root"
+                        ]
                     }
                 }
             },
@@ -429,7 +437,10 @@
                                 "description": "the order of the event within the transaction",
                                 "type": "integer"
                             }
-                        }
+                        },
+                        "required": [
+                            "order"
+                        ]
                     },
                     {
                         "$ref": "#/components/schemas/EVENT"
@@ -449,7 +460,10 @@
                                 "description": "the order of the message within the transaction",
                                 "type": "integer"
                             }
-                        }
+                        },
+                        "required": [
+                            "order"
+                        ]
                     },
                     {
                         "$ref": "#/components/schemas/MSG_TO_L1"
@@ -502,7 +516,10 @@
                                 "REJECTED"
                             ]
                         }
-                    }
+                    },
+                    "required": [
+                        "status"
+                    ]
                 }
             },
             "TXN_HASH_NOT_FOUND": {


### PR DESCRIPTION
Fixes a long-standing issue where the absence of `required` is ambiguous: it could either mean all fields are optional, or that none of them are:

- missing `required` in the `declared_classes` field names they are always present.
- missing `required` in `TXN_RECEIPT_WITH_BLOCK_INFO` means they're all optional.

This makes code generation really difficult as codegen tools have to make external assumptions on what the intended behavior is.

With this PR, now all `properties` are always paired with a valid `required` field.