### PR TITLE
Change StarkNet to Starknet in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# StarkNet Specifications
+# Starknet Specifications
 
-This repository publishes different technical specifications pertaining to the implementation and interaction with StarkNet.
+This repository publishes different technical specifications pertaining to the implementation and interaction with Starknet.
 
 ## API
 


### PR DESCRIPTION
Change `StarkNet` to `Starknet` in the readme of the repo.