### PR TITLE
Adapt execution_resources to new receipt

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3451,128 +3451,27 @@
         },
         "required": ["price_in_wei", "price_in_fri"]
       },
-      "COMPUTATION_RESOURCES": {
-        "title": "Computation resources",
-        "description": "The resources consumed by the VM",
-        "type": "object",
-        "properties": {
-          "steps": {
-            "title": "Steps",
-            "description": "The number of Cairo steps used",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "memory_holes": {
-            "title": "Memory holes",
-            "description": "The number of unused memory cells (each cell is roughly equivalent to a step)",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "range_check_builtin_applications": {
-            "title": "Range check applications",
-            "description": "The number of RANGE_CHECK builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "pedersen_builtin_applications": {
-            "title": "Pedersen applications",
-            "description": "The number of Pedersen builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "poseidon_builtin_applications": {
-            "title": "Poseidon applications",
-            "description": "The number of Poseidon builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "ec_op_builtin_applications": {
-            "title": "EC_OP applications",
-            "description": "the number of EC_OP builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "ecdsa_builtin_applications": {
-            "title": "ECDSA applications",
-            "description": "the number of ECDSA builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "bitwise_builtin_applications": {
-            "title": "BITWISE applications",
-            "description": "the number of BITWISE builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "keccak_builtin_applications": {
-            "title": "Keccak applications",
-            "description": "The number of KECCAK builtin instances",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          },
-          "segment_arena_builtin": {
-            "title": "Segment arena",
-            "description": "The number of accesses to the segment arena",
-            "type": "integer",
-            "not": {
-              "const": 0
-            }
-          }
-        },
-        "required": ["steps"]
-      },
       "EXECUTION_RESOURCES": {
         "type": "object",
         "title": "Execution resources",
-        "description": "the resources consumed by the transaction, includes both computation and data",
-        "allOf": [
-          {
-            "title": "ComputationResources",
-            "$ref": "#/components/schemas/COMPUTATION_RESOURCES"
+        "description": "the resources consumed by the transaction",
+        "properties": {
+          "l1_gas": {
+            "title": "L1Gas",
+            "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
+            "type": "integer"
           },
-          {
-            "type": "object",
-            "title": "DataResources",
-            "description": "the data-availability resources of this transaction",
-            "properties": {
-              "data_availability": {
-                "type": "object",
-                "properties": {
-                  "l1_gas": {
-                    "title": "L1Gas",
-                    "description": "the gas consumed by this transaction's data, 0 if it uses data gas for DA",
-                    "type": "integer"
-                  },
-                  "l1_data_gas": {
-                    "title": "L1DataGas",
-                    "description": "the data gas consumed by this transaction's data, 0 if it uses gas for DA",
-                    "type": "integer"
-                  }
-                },
-                "required": ["l1_gas", "l1_data_gas"]
-              }
-            },
-            "required": ["data_availability"]
+          "l1_data_gas": {
+            "title": "L1DataGas",
+            "description": "data gas consumed by this transaction, 0 if blobs are not used",
+            "type": "integer"
+          },
+          "l2_gas": {
+            "title": "L2Gas",
+            "description": "l2 gas consumed by this transaction, used for computation and calldata",
+            "type": "integer"
           }
-        ]
+        }
       }
     },
     "errors": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1426,6 +1426,11 @@
             "description": "The price of l1 gas in the block",
             "$ref": "#/components/schemas/RESOURCE_PRICE"
           },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The price of l2 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
           "l1_data_gas_price": {
             "title": "L1 data gas price",
             "description": "The price of l1 data gas in the block",
@@ -3346,23 +3351,33 @@
         "title": "Fee estimation",
         "type": "object",
         "properties": {
-          "gas_consumed": {
-            "title": "Gas consumed",
-            "description": "The Ethereum gas consumption of the transaction",
+          "l1_gas_consumed": {
+            "title": "L1 gas consumed",
+            "description": "The Ethereum gas consumption of the transaction, charged for L1->L2 messages and, depending on the block's DA_MODE, state diffs",
             "$ref": "#/components/schemas/FELT"
           },
-          "gas_price": {
-            "title": "Gas price",
+          "l1_gas_price": {
+            "title": "L1 gas price",
             "description": "The gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
             "$ref": "#/components/schemas/FELT"
           },
-          "data_gas_consumed": {
-            "title": "Data gas consumed",
+          "l2_gas_consumed": {
+            "title": "L2 gas consumed",
+            "description": "The L2 gas consumption of the transaction",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The L2 gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_data_gas_consumed": {
+            "title": "L1 data gas consumed",
             "description": "The Ethereum data gas consumption of the transaction",
             "$ref": "#/components/schemas/FELT"
           },
-          "data_gas_price": {
-            "title": "Data gas price",
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
             "description": "The data gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
             "$ref": "#/components/schemas/FELT"
           },


### PR DESCRIPTION
This PR removes the old "raw" execution resources (VM based, with low level info such as memory holes), and adds l2_gas to execution_resources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/216)
<!-- Reviewable:end -->
