### PR TITLE
Replace string with a structured error in CONTRACT_ERROR & TRANSACTION_EXECUTION_ERROR

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3682,6 +3682,36 @@
             "node"
           ]
         }
+    },
+    "CONTRACT_EXECUTION_ERROR": {
+        "description": "structured error that can later be processed by wallets or sdks",
+        "titel": "contract execution error",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "inner call",
+            "description": "error frame",
+            "properties": {
+              "contract_address": {
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "class_hash": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "selector": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "error": {
+                "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+              }
+            }
+          },
+          {
+            "title": "error message",
+            "description": "the error raised during execution",
+            "type": "string"
+          }
+        ]
       }
     },
     "errors": {
@@ -3734,8 +3764,8 @@
           "properties": {
             "revert_error": {
               "title": "revert error",
-              "description": "a string encoding the execution trace up to the point of failure",
-              "type": "string"
+              "description": "the execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
             }
           },
           "required": "revert_error"
@@ -3755,8 +3785,8 @@
             },
             "execution_error": {
               "title": "revert error",
-              "description": "a string encoding the execution trace up to the point of failure",
-              "type": "string"
+              "description": "the§ execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
             }
           },
           "required": ["transaction_index", "execution_error"]

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3785,7 +3785,7 @@
             },
             "execution_error": {
               "title": "revert error",
-              "description": "the§ execution trace up to the point of failure",
+              "description": "the execution trace up to the point of failure",
               "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
             }
           },


### PR DESCRIPTION
In rpc <= 0.7.0, returned errors are strings encoding execution traces (used to be a lot of redundancy, e.g. scary "got an error while executing a hint" repeating a bunch of times, this should already be cleaner in starknet v0.13.2). Now that we have [more structure](https://github.com/starkware-libs/blockifier/blob/b22fb076a7db5e0fcdd2048a6fb579b0b1d25561/crates/blockifier/src/execution/syscalls/hint_processor.rs#L69) (also see [stack_trace.rs](https://github.com/starkware-libs/blockifier/blob/5bccf9ea34101388acb12edcc7d8c9c46f5b415f/crates/blockifier/src/execution/stack_trace.rs#L1)) in the blockifier, we can return the structured data and let sdks/wallets process it rather than rely on string manipulations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/219)
<!-- Reviewable:end -->
