### PR TITLE
Add GetCompiledCasm endpoint

### DIFF
--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,0 +1,1353 @@
+{
+    "openrpc": "1.0.0",
+    "info": {
+        "version": "0.8.0",
+        "title": "API for getting Starknet executables from nodes that store compiled artifacts",
+        "license": {}
+    },
+    "servers": [],
+    "methods": [
+        {
+            "name": "starknet_getCompiledCasm",
+            "summary": "Get the contract class definition in the given block associated with the given hash",
+            "params": [
+                {
+                    "name": "class_hash",
+                    "description": "The hash of the contract class whose CASM will be returned",
+                    "required": true,
+                    "schema": {
+                        "title": "Field element",
+                        "$ref": "#/components/schemas/FELT"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "The compiled contract class",
+                "schema": {
+                    "title": "Starknet get compiled CASM result",
+                    "$ref": "#/components/schemas/CASM_COMPILED_CONTRACT_CLASS"
+                }
+            },
+            "errors": [
+                {
+                    "$ref": "#/components/errors/COMPILATION_ERROR"
+                },
+                {
+                    "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+                }
+            ]
+        }
+    ],
+    "components": {
+        "contentDescriptors": {},
+        "schemas": {
+            "CASM_COMPILED_CONTRACT_CLASS": {
+                "type": "object",
+                "properties": {
+                    "entry_points_by_type": {
+                        "title": "Entry points by type",
+                        "type": "object",
+                        "properties": {
+                            "CONSTRUCTOR": {
+                                "type": "array",
+                                "title": "Constructor",
+                                "items": {
+                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                                }
+                            },
+                            "EXTERNAL": {
+                                "title": "External",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                                }
+                            },
+                            "L1_HANDLER": {
+                                "title": "L1 handler",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                                }
+                            }
+                        },
+                        "required": [
+                            "CONSTRUCTOR",
+                            "EXTERNAL",
+                            "L1_HANDLER"
+                        ]
+                    },
+                    "bytecode": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FELT"
+                        }
+                    },
+                    "prime": {
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
+                    },
+                    "compiler_version": {
+                        "type": "string"
+                    },
+                    "hints": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "description": "2-tuple of pc value and an array of hints to execute",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/HINT"
+                                        }
+                                    }
+                                ]
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                        }
+                    }
+                },
+                "required": [
+                    "prime",
+                    "compiler_version",
+                    "entry_points_by_type",
+                    "bytecode",
+                    "hints"
+                ]
+            },
+            "CASM_ENTRY_POINT": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "builtins": {
+                                "type": "array",
+                                "items": "string"
+                            }
+                        },
+                        "required": "builtins"
+                    }
+                ]
+            },
+            "CellRef": {
+                "title": "CellRef",
+                "type": "object",
+                "properties": {
+                    "register": {
+                        "type": "string",
+                        "enum": [
+                            "AP",
+                            "FP"
+                        ]
+                    },
+                    "offset": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "register",
+                    "offset"
+                ]
+            },
+            "Deref": {
+                "type": "object",
+                "properties": {
+                    "Deref": {
+                        "$ref": "#/components/schemas/CellRef"
+                    }
+                },
+                "required": [
+                    "Deref"
+                ]
+            },
+            "DoubleDeref": {
+                "title": "DoubleDeref",
+                "type": "object",
+                "properties": {
+                    "DoubleDeref": {
+                        "title": "DoubleDeref",
+                        "description": "A (CellRef, offsest) tuple",
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/CellRef"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
+                },
+                "required": [
+                    "DoubleDeref"
+                ]
+            },
+            "Immediate": {
+                "title": "Imeediate",
+                "type": "object",
+                "properties": {
+                    "Immediate": {
+                        "$ref": "#/components/schemas/NUM_AS_HEX"
+                    }
+                },
+                "required": [
+                    "Immediate"
+                ]
+            },
+            "BinOp": {
+                "title": "BinOperand",
+                "type": "object",
+                "properties": {
+                    "BinOp": {
+                        "op": {
+                            "type": "string",
+                            "enum": [
+                                "Add",
+                                "Mul"
+                            ]
+                        },
+                        "a": {
+                            "$ref": "#/components/schemas/CellRef"
+                        },
+                        "b": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/Deref"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/Immediate"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "BinOp",
+                    "a",
+                    "b"
+                ]
+            },
+            "ResOperand": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/Deref"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DoubleDeref"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Immediate"
+                    },
+                    {
+                        "$ref": "#/components/schemas/BinOp"
+                    }
+                ]
+            },
+            "HINT": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/DEPRECATED_HINT"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CORE_HINT"
+                    },
+                    {
+                        "$ref": "#/components/schemas/STARKNET_HINT"
+                    }
+                ]
+            },
+            "DEPRECATED_HINT": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "title": "AssertCurrentAccessIndicesIsEmpty",
+                        "enum": [
+                            "AssertCurrentAccessIndicesIsEmpty"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AssertAllAccessesUsed",
+                        "properties": {
+                            "AssertAllAccessesUsed": {
+                                "type": "object",
+                                "properties": {
+                                    "n_used_accesses": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "n_used_accesses"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AssertAllAccessesUsed"
+                        ]
+                    },
+                    {
+                        "type": "string",
+                        "title": "AssertAllKeysUsed",
+                        "enum": [
+                            "AssertAllKeysUsed"
+                        ]
+                    },
+                    {
+                        "type": "string",
+                        "title": "AssertLeAssertThirdArcExcluded",
+                        "enum": [
+                            "AssertLeAssertThirdArcExcluded"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AssertLtAssertValidInput",
+                        "properties": {
+                            "AssertLtAssertValidInput": {
+                                "type": "object",
+                                "properties": {
+                                    "a": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "b": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "a",
+                                    "b"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AssertLtAssertValidInput"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Felt252DictRead",
+                        "properties": {
+                            "Felt252DictRead": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "key": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "value_dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dict_ptr",
+                                    "key",
+                                    "value_dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Felt252DictRead"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Felt252DictWrite",
+                        "properties": {
+                            "Felt252DictWrite": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "key": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "value": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "dict_ptr",
+                                    "key",
+                                    "value"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Felt252DictWrite"
+                        ]
+                    }
+                ]
+            },
+            "CORE_HINT": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "AllocSegment",
+                        "properties": {
+                            "AllocSegment": {
+                                "type": "object",
+                                "properties": {
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AllocSegment"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "TestLessThan",
+                        "properties": {
+                            "TestLessThan": {
+                                "type": "object",
+                                "properties": {
+                                    "lhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "rhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "lhs",
+                                    "rhs",
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "TestLessThan"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "TestLessThanOrEqual",
+                        "properties": {
+                            "TestLessThanOrEqual": {
+                                "type": "object",
+                                "properties": {
+                                    "lhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "rhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "lhs",
+                                    "rhs",
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "TestLessThanOrEqual"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "TestLessThanOrEqualAddress",
+                        "properties": {
+                            "TestLessThanOrEqualAddress": {
+                                "type": "object",
+                                "properties": {
+                                    "lhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "rhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "lhs",
+                                    "rhs",
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "TestLessThanOrEqualAddress"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "WideMul128",
+                        "properties": {
+                            "WideMul128": {
+                                "type": "object",
+                                "properties": {
+                                    "lhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "rhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "high": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "low": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "lhs",
+                                    "rhs",
+                                    "high",
+                                    "low"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "WideMul128"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "DivMod",
+                        "properties": {
+                            "DivMod": {
+                                "type": "object",
+                                "properties": {
+                                    "lhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "rhs": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "quotient": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "lhs",
+                                    "rhs",
+                                    "quotient",
+                                    "remainder"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "DivMod"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Uint256DivMod",
+                        "properties": {
+                            "Uint256DivMod": {
+                                "type": "object",
+                                "properties": {
+                                    "dividend0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dividend1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "divisor0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "divisor1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "quotient0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "quotient1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dividend0",
+                                    "dividend1",
+                                    "divisor0",
+                                    "divisor1",
+                                    "quotient0",
+                                    "quotient1",
+                                    "remainder0",
+                                    "remainder1"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Uint256DivMod"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Uint512DivModByUint256",
+                        "properties": {
+                            "Uint512DivModByUint256": {
+                                "type": "object",
+                                "properties": {
+                                    "dividend0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dividend1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dividend2": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dividend3": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "divisor0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "divisor1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "quotient0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "quotient1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "quotient2": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "quotient3": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dividend0",
+                                    "dividend1",
+                                    "dividend2",
+                                    "dividend3",
+                                    "divisor0",
+                                    "divisor1",
+                                    "quotient0",
+                                    "quotient1",
+                                    "quotient2",
+                                    "quotient3",
+                                    "remainder0",
+                                    "remainder1"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Uint512DivModByUint256"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "SquareRoot",
+                        "properties": {
+                            "SquareRoot": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "value",
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "SquareRoot"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Uint256SquareRoot",
+                        "properties": {
+                            "Uint256SquareRoot": {
+                                "type": "object",
+                                "properties": {
+                                    "value_low": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "value_high": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "sqrt0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "sqrt1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder_low": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "remainder_high": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "sqrt_mul_2_minus_remainder_ge_u128": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "value_low",
+                                    "value_high",
+                                    "sqrt0",
+                                    "sqrt1",
+                                    "remainder_low",
+                                    "remainder_high",
+                                    "sqrt_mul_2_minus_remainder_ge_u128"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Uint256SquareRoot"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "LinearSplit",
+                        "properties": {
+                            "LinearSplit": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "scalar": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "max_x": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "x": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "y": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "value",
+                                    "scalar",
+                                    "max_x",
+                                    "x",
+                                    "y"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "LinearSplit"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AllocFelt252Dict",
+                        "properties": {
+                            "AllocFelt252Dict": {
+                                "type": "object",
+                                "properties": {
+                                    "segment_arena_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "segment_arena_ptr"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AllocFelt252Dict"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Felt252DictEntryInit",
+                        "properties": {
+                            "Felt252DictEntryInit": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "key": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "dict_ptr",
+                                    "key"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Felt252DictEntryInit"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Felt252DictEntryUpdate",
+                        "properties": {
+                            "Felt252DictEntryUpdate": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "value": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "dict_ptr",
+                                    "value"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Felt252DictEntryUpdate"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "GetSegmentArenaIndex",
+                        "properties": {
+                            "GetSegmentArenaIndex": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_end_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dict_index": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dict_end_ptr",
+                                    "dict_index"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "GetSegmentArenaIndex"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "InitSquashData",
+                        "properties": {
+                            "InitSquashData": {
+                                "type": "object",
+                                "properties": {
+                                    "dict_access": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "ptr_diff": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "n_accesses": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "big_keys": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "first_key": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "dict_access",
+                                    "ptr_diff",
+                                    "n_accesses",
+                                    "big_keys",
+                                    "first_key"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "InitSquashData"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "GetCurrentAccessIndex",
+                        "properties": {
+                            "GetCurrentAccessIndex": {
+                                "type": "object",
+                                "properties": {
+                                    "range_check_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "range_check_ptr"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "GetCurrentAccessIndex"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "ShouldSkipSquashLoop",
+                        "properties": {
+                            "ShouldSkipSquashLoop": {
+                                "type": "object",
+                                "properties": {
+                                    "should_skip_loop": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "should_skip_loop"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "ShouldSkipSquashLoop"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "GetCurrentAccessDelta",
+                        "properties": {
+                            "GetCurrentAccessDelta": {
+                                "type": "object",
+                                "properties": {
+                                    "index_delta_minus1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "index_delta_minus1"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "GetCurrentAccessDelta"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "ShouldContinueSquashLoop",
+                        "properties": {
+                            "ShouldContinueSquashLoop": {
+                                "type": "object",
+                                "properties": {
+                                    "should_continue": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "should_continue"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "ShouldContinueSquashLoop"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "GetNextDictKey",
+                        "properties": {
+                            "GetNextDictKey": {
+                                "type": "object",
+                                "properties": {
+                                    "next_key": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "next_key"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "GetNextDictKey"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AssertLeFindSmallArcs",
+                        "properties": {
+                            "AssertLeFindSmallArcs": {
+                                "type": "object",
+                                "properties": {
+                                    "range_check_ptr": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "a": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "b": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "range_check_ptr",
+                                    "a",
+                                    "b"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AssertLeFindSmallArcs"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AssertLeIsFirstArcExcluded",
+                        "properties": {
+                            "AssertLeIsFirstArcExcluded": {
+                                "type": "object",
+                                "properties": {
+                                    "skip_exclude_a_flag": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "skip_exclude_a_flag"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AssertLeIsFirstArcExcluded"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AssertLeIsSecondArcExcluded",
+                        "properties": {
+                            "AssertLeIsSecondArcExcluded": {
+                                "type": "object",
+                                "properties": {
+                                    "skip_exclude_b_minus_a": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "skip_exclude_b_minus_a"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AssertLeIsSecondArcExcluded"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "RandomEcPoint",
+                        "properties": {
+                            "RandomEcPoint": {
+                                "type": "object",
+                                "properties": {
+                                    "x": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "y": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "x",
+                                    "y"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "RandomEcPoint"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "FieldSqrt",
+                        "properties": {
+                            "FieldSqrt": {
+                                "type": "object",
+                                "properties": {
+                                    "val": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "sqrt": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "val",
+                                    "sqrt"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "FieldSqrt"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "DebugPrint",
+                        "properties": {
+                            "DebugPrint": {
+                                "type": "object",
+                                "properties": {
+                                    "start": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "end": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "start",
+                                    "end"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "DebugPrint"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "AllocConstantSize",
+                        "properties": {
+                            "AllocConstantSize": {
+                                "type": "object",
+                                "properties": {
+                                    "size": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "dst": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "size",
+                                    "dst"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "AllocConstantSize"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "U256InvModN",
+                        "properties": {
+                            "U256InvModN": {
+                                "type": "object",
+                                "properties": {
+                                    "b0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "b1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "n0": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "n1": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "g0_or_no_inv": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "g1_option": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "s_or_r0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "s_or_r1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "t_or_k0": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "t_or_k1": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "b0",
+                                    "b1",
+                                    "n0",
+                                    "n1",
+                                    "g0_or_no_inv",
+                                    "g1_option",
+                                    "s_or_r0",
+                                    "s_or_r1",
+                                    "t_or_k0",
+                                    "t_or_k1"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "U256InvModN"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "EvalCircuit",
+                        "properties": {
+                            "EvalCircuit": {
+                                "type": "object",
+                                "properties": {
+                                    "n_add_mods": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "add_mod_builtin": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "n_mul_mods": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "mul_mod_builtin": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "n_add_mods",
+                                    "add_mod_builtin",
+                                    "n_mul_mods",
+                                    "mul_mod_builtin"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "EvalCircuit"
+                        ]
+                    }
+                ]
+            },
+            "STARKNET_HINT": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "SystemCall",
+                        "properties": {
+                            "SystemCall": {
+                                "type": "object",
+                                "properties": {
+                                    "system": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    }
+                                },
+                                "required": [
+                                    "system"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "SystemCall"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "Cheatcode",
+                        "properties": {
+                            "Cheatcode": {
+                                "type": "object",
+                                "properties": {
+                                    "selector": {
+                                        "$ref": "#/components/schemas/NUM_AS_HEX"
+                                    },
+                                    "input_start": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "input_end": {
+                                        "$ref": "#/components/schemas/ResOperand"
+                                    },
+                                    "output_start": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    },
+                                    "output_end": {
+                                        "$ref": "#/components/schemas/CellRef"
+                                    }
+                                },
+                                "required": [
+                                    "selector",
+                                    "input_start",
+                                    "input_end",
+                                    "output_start",
+                                    "output_end"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "Cheatcode"
+                        ]
+                    }
+                ]
+            },
+            "FELT": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/FELT"
+            },
+            "NUM_AS_HEX": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
+            },
+            "DEPRECATED_CAIRO_ENTRY_POINT": {
+                "$ref": "./starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+            }
+        },
+        "errors": {
+            "CLASS_HASH_NOT_FOUND": {
+                "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
+            },
+            "COMPILATION_ERROR": {
+                "data": {
+                    "type": "object",
+                    "description": "More data about the compilation failure",
+                    "properties": {
+                        "compilation_error": {
+                            "title": "compilation error",
+                            "type": "string"
+                        }
+                    },
+                    "required": "compilation_error"
+                }
+            }
+        }
+    }
+}

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -112,6 +112,13 @@
                         }
                     }
                 },
+                "bytecode_segment_lengths": {
+                    "type": "array",
+                    "description": "a list of sizes of segments in the bytecode, each segment is hashed invidually when computing the bytecode hash",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "required": [
                     "prime",
                     "compiler_version",


### PR DESCRIPTION
Today, all nodes store the compiled CASM artifacts but do not externalize them. Third parties can use them and save the overhead of compilation, concrete usecases are:

- Replay startknet via a json-rpc based state reader, without the new endpoint replay time & complexity may be dominated by compilation
- Running the Starknet OS requires access to compiled CASM (this usecase also requires the `bytecode_segment_lengths` data, which is not stored ATM on nodes, hence it remains optional on the spec)

In this PR we add a `starknet_executables.json` section to the API, with a new endpoint to return the compiled CASM. The specification attempts to reflect the json serialization of [CasmContractClass](https://github.com/starkware-libs/cairo/blob/f1458c8726ad4aa5cedbeaac94027bd1c1d8c912/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs#L111), and should agree with the feeder gateway's `get_compiled_class_by_class_hash` endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/221)
<!-- Reviewable:end -->
