### PR TITLE
Add proven_on_l2 finality status

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2976,13 +2976,13 @@
       "TXN_STATUS": {
         "title": "Transaction status",
         "type": "string",
-        "enum": ["RECEIVED", "REJECTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": ["RECEIVED", "REJECTED", "ACCEPTED_ON_L2", "PROVEN_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase"
       },
       "TXN_FINALITY_STATUS": {
         "title": "Finality status",
         "type": "string",
-        "enum": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": ["ACCEPTED_ON_L2", "PROVEN_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The finality status of the transaction"
       },
       "TXN_EXECUTION_STATUS": {


### PR DESCRIPTION
A few months ago we had a mainnet reorg that was caused by a sequencer/prover mismatch. This new status (pending decision to add it to the SN) will reflect the successful execution of the Starknet OS. This will give a much higher degree of confidence to parties that are now waiting for accepted_on_l1 (e.g. some exchanges). While not really reflecting proof being created, the new status captures all the known issues we had so far (os/blockifier mismatch).

The new status is added to:

- TXN_STATUS (returned on the getTransactionStatus endpoint)
- TXN_FINALITY_STATUS (included in transaction receipts)