### PR TITLE
Add getMessagesStatus endpoint

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -261,6 +261,52 @@
       ]
     },
     {
+      "name": "starknet_getMessagesStatus",
+      "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 ransaction, ordered by the l1 tx sending order",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the L1 transaction that sent L1->L2 messages",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/L1_TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "status",
+            "properties": {
+              "transaction_hash": {
+                "$ref": "#/components/schemas/TXN_HASH"
+              },
+              "finality_status": {
+                "title": "finality status",
+                "$ref": "#/components/schemas/TXN_STATUS"
+              },
+              "failure_reason": {
+                "title": "failure reason",
+                "description": "the failure reason, only appears if finality_status is REJECTED",
+                "type": "string"
+              }
+            },
+            "required": ["transaction_hash", "finality_status"]
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
       "name": "starknet_getTransactionByHash",
       "summary": "Get the details and status of a submitted transaction",
       "paramStructure": "by-name",
@@ -1293,8 +1339,12 @@
       },
       "TXN_HASH": {
         "$ref": "#/components/schemas/FELT",
-        "description": "The transaction hash, as assigned in StarkNet",
+        "description": "The hash of a Starknet transaction",
         "title": "Transaction hash"
+      },
+      "L1_TXN_HASH": {
+        "$ref": "#/components/schemas/NUM_AS_HEX",
+        "description": "The hash of an Ethereum transaction"
       },
       "FELT": {
         "type": "string",


### PR DESCRIPTION
Today, if an l1_handler transaction is rejected, there is no way for the sender to know why it failed other than manually computing the associated l1_handler transaction hash and querying its status. This endpoint basically does that for the user, by starting from the sending l1 transaction, and returning the status of all associated l1_handler transactions on Starknet (a single L1 transaction can send multiple messages)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/223)
<!-- Reviewable:end -->
