### PR TITLE
Add l1_data_gas to the resource bounds mapping

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3567,13 +3567,18 @@
             "description": "The max amount and max price per unit of L1 gas used in this tx",
             "$ref": "#/components/schemas/RESOURCE_BOUNDS"
           },
+          "l1_data_gas": {
+            "title": "L1 Data Gas",
+            "description": "The max amount and max price per unit of L1 blob gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          },
           "l2_gas": {
             "title": "L2 Gas",
             "description": "The max amount and max price per unit of L2 gas used in this tx",
             "$ref": "#/components/schemas/RESOURCE_BOUNDS"
           }
         },
-        "required": ["l1_gas", "l2_gas"]
+        "required": ["l1_gas", "l1_data_gas", "l2_gas"]
       },
       "RESOURCE_BOUNDS": {
         "type": "object",


### PR DESCRIPTION
ATM the transactions (as submitted through the write API) can't specify bounds for l1_data_gas. This PR adds l1_data_gas as a mandatory property to RESORUCE_BOUNDS_MAPPING.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/228)
<!-- Reviewable:end -->
