### PR TITLE
Refactor storage proofs

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1016,8 +1016,13 @@
                     },
                     "classes_tree_root": {
                         "$ref": "#/components/schemas/FELT"
+                    },
+                    "block_hash": {
+                        "description": "the associated block hash (needed in case the caller used a block tag for the block_id parameter)",
+                        "$ref": "#/components/schemas/FELT"
                     }
-                }
+                },
+                "required": ["contracts_tree_root", "classes_tree_root", "block_hash"]
               }
             },
             "required": [

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -969,7 +969,7 @@
         ],
         "result": {
           "name": "result",
-          "description": "The contract's nonce at the requested state",
+          "description": "The requested storage proofs. Note that if a requested leaf has the default value, the path to it may end in an edge node whose path is not a prefix of the requested leaf, thus effecitvely proving non-membership",
           "schema": {
             "type": "object",
             "properties": {
@@ -980,7 +980,7 @@
                 "type": "object",
                 "properties": {
                     "nodes": {
-                        "description": "the nodes in the union of the paths from the contracts tree root to the requested leaves",
+                        "description": "The nodes in the union of the paths from the contracts tree root to the requested leaves",
                         "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
                     },
                     "contract_leaves_data": {
@@ -1031,7 +1031,15 @@
               "contracts_storage_proofs",
               "global_roots"
             ]
-          }
+          },
+          "errors": [
+            {
+              "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+            },
+            {
+              "$ref": "#/components/errors/STORAGE_PROOF_NOT_SUPPORTED"
+            }
+          ]
         }
       }
   ],
@@ -3691,9 +3699,6 @@
             },
             {
                 "$ref": "#/components/schemas/EDGE_NODE"
-            },
-            {
-                "$ref": "#/components/schemas/LEAF_NODE"
             }
         ]
       },
@@ -3718,7 +3723,7 @@
         "properties": {
             "path": {
                 "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant (bounded by 2^251)",
-                "type": "integer"
+                "$ref": "#/components/schemas/NUM_AS_HEX"
             },
             "length": {
                 "description": "the length of the path (bounded by 251)",
@@ -3730,16 +3735,6 @@
             }
         },
         "required": ["path", "length", "child"]
-      },
-      "LEAF_NODE": {
-        "type": "object",
-        "description": "a leaf in the Merkle-Patricia tree",
-        "properties": {
-            "value": {
-                "$ref": "#/components/schemas/FELT"
-            }
-        },
-        "required": ["value"]
       },
       "NODE_HASH_TO_NODE_MAPPING": {
         "description": "a node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root",
@@ -3869,6 +3864,10 @@
           },
           "required": ["transaction_index", "execution_error"]
         }
+      },
+      "STORAGE_PROOF_NOT_SUPPORTED": {
+        "code": 42,
+        "message": "the node doesn't support storage proofs for blocks that are too far in the past"
       }
     }
   }

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -986,7 +986,7 @@
                     "contract_leaves_data": {
                         "type": "array",
                         "items": {
-                            "description": "the nonce and class hash for each requested contract address, these values are needed to compute the associated leaf node",
+                            "description": "The nonce and class hash for each requested contract address, in the order in which they appear in the request. These values are needed to construct the associated leaf node",
                             "type": "object",
                             "properties": {
                                 "nonce": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3717,11 +3717,11 @@
         "description": "represents a path to the highest non-zero descendant node",
         "properties": {
             "path": {
-                "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant",
+                "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant (bounded by 2^251)",
                 "type": "integer"
             },
             "length": {
-                "description": "the length of the path",
+                "description": "the length of the path (bounded by 251)",
                 "type": "integer"
             },
             "child": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -908,55 +908,64 @@
     },
     {
         "name": "starknet_getStorageProof",
-        "summary": "get merkle paths in one of the state tries: global state, classes, individual contract",
+        "summary": "Get merkle paths in one of the state tries: global state, classes, individual contract. A single request can query for any mix of the three types of storage proofs (classes, contracts, and storage).",
         "params": [
-          {
-            "name": "class_hashes",
-            "description": "a list of the class hashes for which we want to prove membership in the classes trie",
-            "required": false,
-            "schema": {
-              "title": "classes",
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FELT"
-              }
-            }
-          },
-          {
-            "name": "contract_addresses",
-            "description": "a list of contracts for which we want to prove membership in the global state trie",
-            "required": false,
-            "schema": {
-              "title": "contracts",
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ADDRESS"
-              }
-            }
-          },
-          {
-            "name": "contracts_storage_keys",
-            "description": "a list of (contract_address, storage_keys) pairs",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "contract_address": {
-                    "$ref": "#/components/schemas/ADDRESS"
-                  },
-                  "storage_keys": {
+            {
+                "name": "block_id",
+                "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+                "required": true,
+                "schema": {
+                    "title": "Block id",
+                    "$ref": "#/components/schemas/BLOCK_ID"
+                }
+            },
+            {
+                "name": "class_hashes",
+                "description": "a list of the class hashes for which we want to prove membership in the classes trie",
+                "required": false,
+                "schema": {
+                    "title": "classes",
+                    "type": "array",
+                        "items": {
+                        "$ref": "#/components/schemas/FELT"
+                    }
+                }
+            },
+            {
+                "name": "contract_addresses",
+                "description": "a list of contracts for which we want to prove membership in the global state trie",
+                "required": false,
+                "schema": {
+                    "title": "contracts",
+                    "type": "array",
+                        "items": {
+                        "$ref": "#/components/schemas/ADDRESS"
+                    }
+                }
+            },
+            {
+                "name": "contracts_storage_keys",
+                "description": "a list of (contract_address, storage_keys) pairs",
+                "required": false,
+                "schema": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/FELT"
+                        "type": "object",
+                        "properties": {
+                            "contract_address": {
+                                "$ref": "#/components/schemas/ADDRESS"
+                            },
+                            "storage_keys": {
+                                "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/FELT"
+                                    }
+                                }
+                        },
+                        "required": ["contract_address", "storage_keys"]
                     }
-                  }
-                },
-                "required": ["contract_address", "storage_keys"]
-              }
+                }
             }
-          }
         ],
         "result": {
           "name": "result",
@@ -968,19 +977,54 @@
                 "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
               },
               "contracts_proof": {
-                "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+                "type": "object",
+                "properties": {
+                    "nodes": {
+                        "description": "the nodes in the union of the paths from the contracts tree root to the requested leaves",
+                        "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+                    },
+                    "contract_leaves_data": {
+                        "type": "array",
+                        "items": {
+                            "description": "the nonce and class hash for each requested contract address, these values are needed to compute the associated leaf node",
+                            "type": "object",
+                            "properties": {
+                                "nonce": {
+                                    "$ref": "#/components/schemas/FELT"
+                                },
+                                "class_hash": {
+                                    "$ref": "#/components/schemas/FELT"
+                                }
+                            },
+                            "required": ["nonce", "class_hash"] 
+                        }
+                    }
+                },
+                "required": ["nodes", "contract_leaves_data"]
               },
               "contracts_storage_proofs": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
                 }
+              },
+              "global_roots": {
+                "type": "object",
+                "properties": {
+                    "contracts_tree_root": {
+                        "$ref": "#/components/schemas/FELT"
+                    },
+                    "classes_tree_root": {
+                        "$ref": "#/components/schemas/FELT"
+                    }
+                }
               }
             },
             "required": [
               "classes_proof",
               "contracts_proof",
-              "contracts_storage_proofs"
+              "contracts_storage_proofs",
+              "global_roots"
             ]
           }
         }
@@ -3634,42 +3678,66 @@
         "required": ["l1_gas", "l1_data_gas", "l2_gas"]
       },
       "MERKLE_NODE": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "integer"
-          },
-          "length": {
-            "type": "integer"
-          },
-          "value": {
-            "$ref": "#/components/schemas/FELT"
-          },
-          "children_hashes": {
-            "type": "object",
-            "description": "the hash of the child nodes, if not present then the node is a leaf",
-            "properties": {
-              "left": {
-                "$ref": "#/components/schemas/FELT"
-              },
-              "right": {
-                "$ref": "#/components/schemas/FELT"
-              }
+        "title": "MP node",
+        "description": "a node in the Merkle-Patricia tree, can be a leaf, binary node, or an edge node",
+        "oneOf": [
+            {
+                "$ref": "#/components/schemas/BINARY_NODE"
             },
-            "required": [
-              "left",
-              "right"
-            ]
-          }
-        },
-        "required": [
-          "path",
-          "length",
-          "value"
+            {
+                "$ref": "#/components/schemas/EDGE_NODE"
+            },
+            {
+                "$ref": "#/components/schemas/LEAF_NODE"
+            }
         ]
       },
+      "BINARY_NODE": {
+        "type": "object",
+        "description": "an internal node whose both children are non-zero",
+        "properties": {
+            "left": {
+                "description": "the hash of the left child",
+                "$ref": "#/components/schemas/FELT"
+            },
+            "right": {
+                "description": "the hash of the right child",
+                "$ref": "#/components/schemas/FELT"
+            }
+        },
+        "required": ["left", "right"]
+      },
+      "EDGE_NODE": {
+        "type": "object",
+        "description": "represents a path to the highest non-zero descendant node",
+        "properties": {
+            "path": {
+                "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant",
+                "type": "integer"
+            },
+            "length": {
+                "description": "the length of the path",
+                "type": "integer"
+            },
+            "child": {
+                "description": "the hash of the unique non-zero maximal-height descendant node",
+                "$ref": "#/components/schemas/FELT"
+            }
+        },
+        "required": ["path", "length", "child"]
+      },
+      "LEAF_NODE": {
+        "type": "object",
+        "description": "a leaf in the Merkle-Patricia tree",
+        "properties": {
+            "value": {
+                "$ref": "#/components/schemas/FELT"
+            }
+        },
+        "required": ["value"]
+      },
       "NODE_HASH_TO_NODE_MAPPING": {
-        "description": "a node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root (for each node present, its sibling is also present)",
+        "description": "a node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root",
         "type": "array",
         "items": {
           "type": "object",


### PR DESCRIPTION
This PR makes the following changes to the `getStorageProof` endpoint:

- add `block_id` argument
- include storage proofs "metadata" for contracts, namely the nonce and class hash
- add the contracts and classes roots to the response
- changed MerkleNode to speak in terms of binary/edge/leaf node rather than in the (length, path, value) terminology

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/232)
<!-- Reviewable:end -->
