### PR TITLE
Typo and versioning fixes

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.7.1",
+    "version": "0.8.0-rc.0",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -250,7 +250,7 @@
     },
     {
         "name": "starknet_getMessagesStatus",
-        "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 ransaction, ordered by the l1 tx sending order",
+        "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 transaction, ordered by the l1 tx sending order",
         "paramStructure": "by-name",
         "params": [
             {

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
     "openrpc": "1.0.0",
     "info": {
-        "version": "0.8.0",
+        "version": "0.8.0-rc.0",
         "title": "API for getting Starknet executables from nodes that store compiled artifacts",
         "license": {}
     },

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.7.1",
+    "version": "0.8.0-rc.0",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.7.1",
+    "version": "0.8.0-rc.0",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -2,7 +2,7 @@
   "openrpc": "1.3.2",
   "info": {
     "version": "0.8.0-rc0",
-    "title": "StarkNet WebSocket PRC API",
+    "title": "StarkNet WebSocket RPC API",
     "license": {}
   },
   "methods": [


### PR DESCRIPTION
- Fix typos
- Unify versioning; set `version` property to `0.8.0-rc.0`:
  - Currently only `api/starknet_ws_api.json` uses this semver.
  - [ ] Should Wallet API be 0.7.2 (current value) or should it also be labelled with 0.8.0-rc.0?
