### PR TITLE
Rename block param of ws methods to block_id

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -12,7 +12,7 @@
       "description": "Creates a WebSocket stream which will fire events for new block headers",
       "params": [
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
@@ -78,7 +78,7 @@
           }
         },
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
@@ -138,7 +138,7 @@
           }
         },
         {
-          "name": "block",
+          "name": "block_id",
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {


### PR DESCRIPTION
Continuing on the [discussion from Slack](https://spaceshard.slack.com/archives/C03QN20522D/p1731082431554749).
Closes #245 (someone please link the issue as closeable since I can't).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/246)
<!-- Reviewable:end -->
