### PR TITLE
Refine compilation error in the write api

### DIFF
--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -255,7 +255,8 @@
       },
       "COMPILATION_FAILED": {
         "code": 56,
-        "message": "Compilation failed"
+        "message": "Compilation failed",
+        "data": "string"
       },
       "CONTRACT_CLASS_SIZE_IS_TOO_LARGE": {
         "code": 57,


### PR DESCRIPTION
Today, compilation can fail due to various reasons. The most common ones are:

- artifact (class or compiled class) exceeds the bytecode/size limits described [here](https://docs.starknet.io/tools/limits-and-triggers/#current_limits)
- unapproved libfuncs are used

While the gateway responds with the compilation error, it is not forwarded to the RPC consumer which receives the opaque "compilation failed"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/251)
<!-- Reviewable:end -->
