### PR TITLE
Fix JSDoc Type Syntax and Parameter Naming

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -42,7 +42,7 @@ async function fetchExternalRefsFor(docToParse) {
  * For a given dereferencer object, make sure its initial refs don't include refs that are already
  * in the ref cache it has. So it won't try to resolve these.
  *
- * @param {Dereferencer} dereffer The dereferncer object
+ * @param {Dereferencer} dereffer The dereferencer object
  * @returns The amended dereferencer.
  */
 function fixRefs(dereffer) {
@@ -79,7 +79,7 @@ async function derefAll(doc) {
 
 /**
  * Retrieve external schema definitions, from other files.
- * @param {Map<string,string} externalRefs Mapping of schema definitions, pointing to external files.
+ * @param {Map<string,string>} externalRefs Mapping of schema definitions, pointing to external files.
  * @returns The actual referenced schema objects
  */
 async function fetchExternalSchemas(externalRefs) {


### PR DESCRIPTION
### 1. JSDoc Type Syntax Fix:

**{Map<string,string} - {Map<string,string>}**

> Change: Added missing > in type definition
Explanation: Fixed JSDoc syntax by adding the missing closing angle bracket in the Map type definition
Impact of the typo:
IDE type checking may fail or work incorrectly
Documentation generators might fail to parse the type
TypeScript compilation could fail if using TypeScript
Auto-completion features might not work properly
Could cause confusion for other developers reading the code

### 2. JSDoc Parameter Description:

**Change: Fixed typo in dereferncer → dereferencer**

> Explanation: Corrected the misspelling where 'n' and 'c' were transposed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/264)
<!-- Reviewable:end -->
