### PR TITLE
Add storage_root to contracts leaf data

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -994,6 +994,9 @@
                       },
                       "class_hash": {
                         "$ref": "#/components/schemas/FELT"
+                      },
+                      "storage_root": {
+                        "$ref": "#/components/schemas/FELT"
                       }
                     },
                     "required": ["nonce", "class_hash"]


### PR DESCRIPTION
In some usecases, a storage proof for a contract is required without any particular storage keys, e.g. in the case of deployment with no storage updates. The current response structure is missing the contract storage trie root for those cases (it only exists implicitly in the response upon requesting a proof for a specific storage slot).

To remedy this, we add the `storage_root` property to `contract_leaves_data`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/265)
<!-- Reviewable:end -->
