### PR TITLE
Add is_reverted to internal calls within the trace

### DIFF
--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -360,7 +360,7 @@
               "is_reverted": {
                 "title": "Is Reverted",
                 "description": "true if this inner call panicked",
-                "type": "bool"
+                "type": "boolean"
               }
             },
             "required": [

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -356,6 +356,11 @@
                 "title": "Execution resources",
                 "description": "Resources consumed by the internal call",
                 "$ref": "#/components/schemas/INNER_CALL_EXECUTION_RESOURCES"
+              },
+              "is_reverted": {
+                "title": "Is Reverted",
+                "description": "true if this inner call panicked",
+                "type": "bool"
               }
             },
             "required": [
@@ -367,7 +372,8 @@
               "calls",
               "events",
               "messages",
-              "execution_resources"
+              "execution_resources",
+              "is_reverted"
             ]
           }
         ]


### PR DESCRIPTION
As of Starknet v0.13.4, contracts can errors in called contracts (the entire transaction is not necessarily reverted). This means that we now need the execution status at the inner-call level to distinguish failed calls from successful ones.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/266)
<!-- Reviewable:end -->
