### PR TITLE
Add ENTRYPOINT_NOT_FOUND error to starknet_call

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -629,6 +629,9 @@
           "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
         },
         {
+          "$ref": "#/components/errors/ENTRYPOINT_NOT_FOUND"
+        },
+        {
           "$ref": "#/components/errors/CONTRACT_ERROR"
         },
         {
@@ -3801,6 +3804,10 @@
       "CONTRACT_NOT_FOUND": {
         "code": 20,
         "message": "Contract not found"
+      },
+      "ENTRYPOINT_NOT_FOUND": {
+        "code": 21,
+        "message": "Requested entrypoint does not exist in the contract"
       },
       "BLOCK_NOT_FOUND": {
         "code": 24,


### PR DESCRIPTION
While irrelevant for endpoints that receive a transaction (whose entrypoints are fixed), the `starknet_call` endpoint is the only method that is expected to start at a given selector. Nodes today can already distinguish this error from execution errors, hence it is reasonable to add `ENTRYPOINT_NOT_FOUND` to `starknet_call`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/267)
<!-- Reviewable:end -->
