### PR TITLE
Remove old transaction support from the write api

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2157,135 +2157,15 @@
       },
       "BROADCASTED_INVOKE_TXN": {
         "title": "Broadcasted invoke transaction",
-        "$ref": "#/components/schemas/INVOKE_TXN"
+        "$ref": "#/components/schemas/INVOKE_TXN_V3"
       },
       "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
         "title": "Broadcasted deploy account transaction",
-        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
       },
       "BROADCASTED_DECLARE_TXN": {
         "title": "Broadcasted declare transaction",
-        "oneOf": [
-          {
-            "title": "Broadcasted declare transaction V1",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V1"
-          },
-          {
-            "title": "Broadcasted declare transaction V2",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V2"
-          },
-          {
-            "title": "Broadcasted declare transaction V3",
-            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
-          }
-        ]
-      },
-      "BROADCASTED_DECLARE_TXN_V1": {
-        "title": "Broadcasted declare contract transaction V1",
-        "allOf": [
-          {
-            "type": "object",
-            "title": "Declare txn v1",
-            "properties": {
-              "type": {
-                "title": "Declare",
-                "type": "string",
-                "enum": ["DECLARE"]
-              },
-              "sender_address": {
-                "title": "Sender address",
-                "description": "The address of the account contract sending the declaration transaction",
-                "$ref": "#/components/schemas/ADDRESS"
-              },
-              "max_fee": {
-                "title": "Max fee",
-                "$ref": "#/components/schemas/FELT",
-                "description": "The maximal fee that can be charged for including the transaction"
-              },
-              "version": {
-                "title": "Version",
-                "description": "Version of the transaction scheme",
-                "type": "string",
-                "enum": ["0x1", "0x100000000000000000000000000000001"]
-              },
-              "signature": {
-                "title": "Signature",
-                "$ref": "#/components/schemas/SIGNATURE"
-              },
-              "nonce": {
-                "title": "Nonce",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "contract_class": {
-                "title": "Contract class",
-                "description": "The class to be declared",
-                "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
-              }
-            },
-            "required": ["type", "sender_address", "max_fee", "version", "signature", "nonce", "contract_class"]
-          }
-        ]
-      },
-      "BROADCASTED_DECLARE_TXN_V2": {
-        "title": "Broadcasted declare Transaction V2",
-        "description": "Broadcasted declare Contract Transaction V2",
-        "allOf": [
-          {
-            "type": "object",
-            "title": "Declare txn v2",
-            "properties": {
-              "type": {
-                "title": "Declare",
-                "type": "string",
-                "enum": ["DECLARE"]
-              },
-              "sender_address": {
-                "title": "Sender address",
-                "description": "The address of the account contract sending the declaration transaction",
-                "$ref": "#/components/schemas/ADDRESS"
-              },
-              "compiled_class_hash": {
-                "title": "Compiled class hash",
-                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "max_fee": {
-                "title": "Max fee",
-                "$ref": "#/components/schemas/FELT",
-                "description": "The maximal fee that can be charged for including the transaction"
-              },
-              "version": {
-                "title": "Version",
-                "description": "Version of the transaction scheme",
-                "type": "string",
-                "enum": ["0x2", "0x100000000000000000000000000000002"]
-              },
-              "signature": {
-                "title": "Signature",
-                "$ref": "#/components/schemas/SIGNATURE"
-              },
-              "nonce": {
-                "title": "Nonce",
-                "$ref": "#/components/schemas/FELT"
-              },
-              "contract_class": {
-                "title": "Contract class",
-                "description": "The class to be declared",
-                "$ref": "#/components/schemas/CONTRACT_CLASS"
-              }
-            },
-            "required": [
-              "type",
-              "sender_address",
-              "compiled_class_hash",
-              "max_fee",
-              "version",
-              "signature",
-              "nonce",
-              "contract_class"
-            ]
-          }
-        ]
+        "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
       },
       "BROADCASTED_DECLARE_TXN_V3": {
         "title": "Broadcasted declare Transaction V3",


### PR DESCRIPTION
In Starknet v0.14.0, only v3 transactions that sign all three resources will be supported. To help prepare the ecosystem, we remove v<3 transactions support from the write API, simulation, and fee estimation. Old transaction versions will only appear in the JSON-RPC to accommodate existing blocks on the network.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/269)
<!-- Reviewable:end -->
