### PR TITLE
Remove option for pending from all subsriptions

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -16,7 +16,7 @@
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
-            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_ID"
           }
         }
       ],
@@ -32,9 +32,6 @@
         },
         {
           "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
-        },
-        {
-            "$ref": "#/components/errors/CALL_ON_PENDING"
         }
       ]
     },
@@ -85,7 +82,7 @@
           "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
           "required": false,
           "schema": {
-            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_ID"
           }
         }
       ],
@@ -104,9 +101,6 @@
         },
         {
           "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
-        },
-        {
-            "$ref": "#/components/errors/CALL_ON_PENDING"
         }
       ]
     },
@@ -313,6 +307,44 @@
           "type": "integer"
         }
       },
+      "SUBSCRIPTION_BLOCK_ID": {
+        "title": "Subscription Block id",
+        "description": "Block hash, number or tag, same as BLOCK_ID, but without 'pending'",
+        "oneOf": [
+          {
+            "title": "Block hash",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+              }
+            },
+            "required": ["block_hash"]
+          },
+          {
+            "title": "Block number",
+            "type": "object",
+            "properties": {
+              "block_number": {
+                "title": "Block number",
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+              }
+            },
+            "required": ["block_number"]
+          },
+          {
+            "title": "Block tag",
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_TAG"
+          }
+        ]
+      },
+      "SUBSCRIPTION_BLOCK_TAG": {
+        "title": "Subscription Block tag",
+        "type": "string",
+        "description": "Same as BLOCK_TAG, but without 'pending'",
+        "enum": ["latest"]
+      },
       "REORG_DATA": {
         "name": "Reorg Data",
         "description": "Data about reorganized blocks, starting and ending block number and hash",
@@ -353,10 +385,6 @@
       "TOO_MANY_BLOCKS_BACK": {
         "code": 68,
         "message": "Cannot go back more than 1024 blocks"
-      },
-      "CALL_ON_PENDING": {
-        "code": 69,
-        "message": "This method does not support being called on the pending block"
       }
     }
   }


### PR DESCRIPTION
Adds a new type, SUBSCRIPTION_BLOCK_ID, similar to BLOCK_ID, but without `pending`. This will become redundant in 0.14.0, when both will converge.

* Removes the CALL_ON_PENDING error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/272)
<!-- Reviewable:end -->
