### PR TITLE
Update inner-call resources description

### DIFF
--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -354,7 +354,7 @@
               },
               "execution_resources": {
                 "title": "Execution resources",
-                "description": "Resources consumed by the internal call",
+                "description": "Resources consumed by the call tree rooted at this given call (including the root)",
                 "$ref": "#/components/schemas/INNER_CALL_EXECUTION_RESOURCES"
               },
               "is_reverted": {


### PR DESCRIPTION
In past versions of the json-rpc and Starknet, the behavior of execution resources within the trace was the following: the computation resources for every call is actually the resources of the subtree rooted at this call.

While not intuitive, this behavior originates in the blockifier structure, and will probably change in future versions. For the time being, we modify the description to clarify the existing semantics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/273)
<!-- Reviewable:end -->
