### PR TITLE
Revert entry point offset change

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3200,7 +3200,7 @@
           "offset": {
             "title": "Offset",
             "description": "The offset of the entry point in the program",
-            "type": "integer"
+            "$ref": "#/components/schemas/NUM_AS_HEX"
           },
           "selector": {
             "title": "Selector",


### PR DESCRIPTION
v0.8.0-rc2 includes a change of `offset` within the entrypoints of deprecated classes from NUM_AS_HEX to integers.

While integer does make more sense, we wish to avoid changes for deprecated offsets, which are already served in the "bad" way in older rpc versions. In particular, v0.8.0 is bound to Starknet v0.13.4, hence we want node teams to focus on critical changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/275)
<!-- Reviewable:end -->
