### PR TITLE
Update description for `starknet_estimateFee`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -605,7 +605,7 @@
     {
       "name": "starknet_estimateFee",
       "summary": "estimate the fee for of StarkNet transactions",
-      "description": "Estimates the resources required by a given sequence of transactions when applied on a given state. If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error), a TRANSACTION_EXECUTION_ERROR is returned. For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.",
+      "description": "Estimates the resources required by a given sequence of transactions when applied on a given state. If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error), a TRANSACTION_EXECUTION_ERROR is returned. The estimate is given in fri.",
       "params": [
         {
           "name": "request",


### PR DESCRIPTION
`estimateFee` receives `BROADCASTED_TXN` which are only `v3` in `v0.8.0`, so remove description for `v0-2`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/277)
<!-- Reviewable:end -->
