### PR TITLE
Change entrypoint offset type for new classes

### DIFF
--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -128,25 +128,26 @@
                 ]
             },
             "CASM_ENTRY_POINT": {
-                "schema": {
-                    "allOf": [
-                        {
-                            "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "builtins": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "required": ["builtins"]
+                "type": "object",
+                "properties": {
+                    "offset": {
+                        "title": "Offset",
+                        "description": "The offset of the entry point in the program",
+                        "type": "integer"
+                    },
+                    "selector": {
+                        "title": "Selector",
+                        "description": "A unique identifier of the entry point (function) in the program",
+                        "$ref": "#/components/schemas/FELT"
+                    },
+                    "builtins": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
                         }
-                    ]
-                }
+                    }
+                },
+                "required": ["offset", "selector", "builtins"]
             },
             "CellRef": {
                 "title": "CellRef",


### PR DESCRIPTION
The integer --> NUM_AS_HEX rollback was supposed to affect only Cairo0 classes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/278)
<!-- Reviewable:end -->
