### PR TITLE
Update starknet_executables.json, fix 'dict_access'

### DIFF
--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -913,7 +913,7 @@
                                     }
                                 },
                                 "required": [
-                                    "dict_access",
+                                    "dict_accesses",
                                     "ptr_diff",
                                     "n_accesses",
                                     "big_keys",


### PR DESCRIPTION
I believe the correct one is `dict_accesses`. Am I right?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/280)
<!-- Reviewable:end -->
