### PR TITLE
Fix summary of starknet_getCompiledCasm

### DIFF
--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -9,7 +9,7 @@
     "methods": [
         {
             "name": "starknet_getCompiledCasm",
-            "summary": "Get the contract class definition in the given block associated with the given hash",
+            "summary": "Get the CASM code resulting from compiling a given class",
             "params": [
                 {
                     "name": "class_hash",


### PR DESCRIPTION
The summary was copied from the getClass method and is not updated, closes #279

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/281)
<!-- Reviewable:end -->
