### PR TITLE
Disallow storage proof requests from the pending block

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -889,7 +889,17 @@
           "required": true,
           "schema": {
             "title": "Block id",
-            "$ref": "#/components/schemas/BLOCK_ID"
+            "allOf": [
+                {
+                    "$ref": "#/components/schemas/BLOCK_ID"
+                },
+                {
+                    "not": {
+                      "type": "string",
+                      "enum": ["pending"]
+                    }
+                }
+            ]
           }
         },
         {


### PR DESCRIPTION
As the title suggets, storage proofs from the pending block are not well defined and may result in inconsistency between requests and node implementations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/282)
<!-- Reviewable:end -->
