### PR TITLE
Update INSUFFICIENT_ACCOUNT_BALANCE error text

### DIFF
--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -240,7 +240,7 @@
       },
       "INSUFFICIENT_ACCOUNT_BALANCE": {
         "code": 54,
-        "message": "Account balance is smaller than the transaction's max_fee"
+        "message": "Account balance is smaller than the transaction's maximal fee (calculated as the sum of each resource's limit x max price)"
       },
       "VALIDATION_FAILURE": {
         "code": 55,


### PR DESCRIPTION
This PR removes the explicit mention of max_fee field from the INSUFFICIENT_ACCOUNT_BALANCE text.

Closes #284

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/285)
<!-- Reviewable:end -->
