### PR TITLE
fix: change subscription_id from integer to string

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -304,7 +304,7 @@
         "name": "subscription id",
         "description": "An identifier for this subscription stream used to associate events with this subscription.",
         "schema": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "SUBSCRIPTION_BLOCK_ID": {


### PR DESCRIPTION
To secure arbitrary shape and form (ex. 'large number' strings) for subscription_id, as so for js to support it should be a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/288)
<!-- Reviewable:end -->
