### PR TITLE
Fix: quotation mark

### DIFF
--- a/starknet_vs_ethereum_node_apis.md
+++ b/starknet_vs_ethereum_node_apis.md
@@ -50,17 +50,17 @@ We list below the methods in Ethereum's API and their corresponding StarkNet met
 |---------------|---------------|-------------------------|
 |eth_blockNumber|starknet_blockNumber|Will return only the block number |
 |eth_chainId|starknet_chainId| |
-|eth_getBlockByNumber|starknet_getBlockByNumber|<ul><li> Doesn’t have the include transactions input.</li><li> The result key is “result”.</li></ul> |
-|eth_getBlockTransactionCountByHash|starknet_getBlockTransactionCountByHash|<ul><li> Supports also “latest” block tag as input</li><li> The result is always an integer</li><li> The response key is “result”.</li><li> May return an error for invalid block hash.</li></ul> |
-|eth_getBlockTransactionCountByNumber|starknet_getBlockTransactionCountByNumber|<ul><li> Block number input is given as a decimal integer.</li><li> The result key is “result”.</li><li> May return an error for invalid block number.</li></ul> |
+|eth_getBlockByNumber|starknet_getBlockByNumber|<ul><li> Doesn’t have the include transactions input.</li><li> The result key is "result".</li></ul> |
+|eth_getBlockTransactionCountByHash|starknet_getBlockTransactionCountByHash|<ul><li> Supports also "latest" block tag as input</li><li> The result is always an integer</li><li> The response key is "result".</li><li> May return an error for invalid block hash.</li></ul> |
+|eth_getBlockTransactionCountByNumber|starknet_getBlockTransactionCountByNumber|<ul><li> Block number input is given as a decimal integer.</li><li> The result key is "result".</li><li> May return an error for invalid block number.</li></ul> |
 |eth_getTransactionByBlockHashAndIndex|starknet_getTransactionByBlockHashAndIndex|<li> The Index is given as a decimal integer. |
 |eth_getTransactionByBlockNumberAndIndex|starknet_getTransactionByBlockNumberAndIndex|<li> The index is given as a decimal integer. |
-|eth_pendingTransactions|starknet_pendingTransactions|<ul><li> The result key is “result”.</li><li> Will not return market fee parameters.</li></ul> |
-|eth_getBlockByHash|starknet_getBlockByHash|<ul><li> Doesn’t have the include transactions input.</li><li> The result key is “result”.</li></ul> |
+|eth_pendingTransactions|starknet_pendingTransactions|<ul><li> The result key is "result".</li><li> Will not return market fee parameters.</li></ul> |
+|eth_getBlockByHash|starknet_getBlockByHash|<ul><li> Doesn’t have the include transactions input.</li><li> The result key is "result".</li></ul> |
 |eth_protocolVersion|starknet_protocolVersion|
 |eth_syncing|starknet_syncing|<li> The result will not include known and pulled states
-|eth_getStorageAt|starknet_getStorageAt|<ul><li> Accepts a block hash instead of a block number</li><li> The result key is “result”.</li><li> The result type is a field element.</li><li> Will return errors for invalid contract or storage keys.</li></ul> |
-|eth_getTransactionByHash|starknet_getTransactionByHash|<ul><li> Input key is “transaction_hash”.</li><li> The result key is “result”.</li><li> Will not return null.</li><li> Will return an error for an invalid transaction hash.</li></ul> |
-|eth_getTransactionReceipt|starknet_getTransactionReceipt|<ul><li> Input key is “transaction_hash”.</li><li> The result key is “result”.</li><li> Will not return null.</li><li> Will return an error for an invalid transaction hash.</li></ul> |
-|eth_getCode|starknet_getCode|<ul><li> The input key is “contract_address”.</li><li> Does not accept a block number.</li><li> Will return byte code (field elements) and ABI.</li><li> Will return an error for an invalid contract address.</li></ul> |
+|eth_getStorageAt|starknet_getStorageAt|<ul><li> Accepts a block hash instead of a block number</li><li> The result key is "result".</li><li> The result type is a field element.</li><li> Will return errors for invalid contract or storage keys.</li></ul> |
+|eth_getTransactionByHash|starknet_getTransactionByHash|<ul><li> Input key is "transaction_hash".</li><li> The result key is "result".</li><li> Will not return null.</li><li> Will return an error for an invalid transaction hash.</li></ul> |
+|eth_getTransactionReceipt|starknet_getTransactionReceipt|<ul><li> Input key is "transaction_hash".</li><li> The result key is "result".</li><li> Will not return null.</li><li> Will return an error for an invalid transaction hash.</li></ul> |
+|eth_getCode|starknet_getCode|<ul><li> The input key is "contract_address".</li><li> Does not accept a block number.</li><li> Will return byte code (field elements) and ABI.</li><li> Will return an error for an invalid contract address.</li></ul> |
 |eth_call|starknet_call|<ul><li> Input transaction is different.</li><li> Input block designated by hash.</li><li> Will return errors for invalid contract address| message selector| call data| or general error.</li></ul> |


### PR DESCRIPTION
Some editors may not accurately render unexpected characters, appearing as gibberish or causing formatting problems.