### PR TITLE
Update .github/pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,5 @@
 - [ ] Validated the specification files - `npm run validate_all`
 - [ ] Applied formatting - `npm run format`
 - [ ] Performed code self-review
-- [ ] If making a new release, checked out [the guidelines](../api/release.md)
+- [ ] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
+- [ ] If making a new release, checked out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)


### PR DESCRIPTION
## Changes

- Fix link to api/release.md
  - Currently only works if the PR template is [opened as a GitHub file](https://github.com/starkware-libs/starknet-specs/blob/master/.github/pull_request_template.md)
- Add link to the Issues page to remind contributors to close issues and reduce the backlog.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] If making a new release, checked out [the guidelines](../api/release.md)
