### PR TITLE
fixed typo `itmes`

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -790,7 +790,7 @@
             "type": "object",
             "additionalProperties": {
               "type": "array",
-              "itmes": {
+              "items": {
                 "$ref": "#/components/schemas/STARKNET_TYPE"
               }
             }


### PR DESCRIPTION
## Changes

Hi! I fixed a typo in the `wallet_rpc.json` specification file. Replaced `"itmes"` with `"items"` in the schema definition. 

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
