### PR TITLE
Change subscription_id parameter type of starknet_unsubscribe

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -260,7 +260,7 @@
           "summary": "The subscription to close",
           "required": true,
           "schema": {
-            "type": "integer"
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
           }
         }
       ],


### PR DESCRIPTION
## Changes

subscription_id type is changed from integer to SUBSCRIPTION_ID
change version from 0.8.0 to 0.8.1

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [ ] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-specs/296)
<!-- Reviewable:end -->
