### PR TITLE
fix: `INVALID_TRANSACTION_NONCE` error data type

### DIFF
--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -251,7 +251,24 @@
       "INVALID_TRANSACTION_NONCE": {
         "code": 52,
         "message": "Invalid transaction nonce",
-        "data": "Invalid transaction nonce of contract at address <ADDRESS>. Account nonce: <NONCE>; got: <PAYLOAD_NONCE>."
+        "data": {
+          "type": "object",
+          "description": "More data about the nonce mismatch failure",
+          "properties": {
+            "address": {
+              "title": "Account contract address",
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/ADDRESS"
+            },
+            "expected_nonce": {
+              "title": "Nonce expected by the account contract",
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+            },
+            "payload_nonce": {
+              "title": "Actual nonce delivered on the payload",
+              "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+            }
+          }
+        }
       },
       "INSUFFICIENT_RESOURCES_FOR_VALIDATE": {
         "code": 53,


### PR DESCRIPTION
## Changes

The current error `data` type of `INVALID_TRANSACTION_NONCE` is defined as a template message string, but error `data` is actually supposed to be structured data for programmatic access. This patch fixes it by making it structured.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
