### PR TITLE
Modify `pre_confirmed_block_header`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3135,7 +3135,12 @@
       "BLOCK_STATUS": {
         "title": "Block status",
         "type": "string",
-        "enum": ["PRE_CONFIRMED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"],
+        "enum": [
+          "PRE_CONFIRMED",
+          "ACCEPTED_ON_L2",
+          "ACCEPTED_ON_L1",
+          "REJECTED"
+        ],
         "description": "The status of the block"
       },
       "FUNCTION_CALL": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1272,20 +1272,20 @@
       },
       "NUM_AS_HEX": {
         "title": "Number as hex",
-        "description": "An integer number in hex format (0x...)",
+        "description": "An unsigned integer number in hex format (0x...)",
         "type": "string",
         "pattern": "^0x[a-fA-F0-9]+$"
       },
       "u64": {
         "type": "string",
         "title": "u64",
-        "description": "64 bit integers, represented by hex string of length at most 16",
+        "description": "64 bit unsigned integers, represented by hex string of length at most 16",
         "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,15})$"
       },
       "u128": {
         "type": "string",
         "title": "u128",
-        "description": "128 bit integers, represented by hex string of length at most 32",
+        "description": "128 bit unsigned integers, represented by hex string of length at most 32",
         "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,31})$"
       },
       "CHAIN_ID": {
@@ -3298,7 +3298,8 @@
           "function_idx": {
             "title": "Function index",
             "description": "The index of the function in the program",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": ["selector", "function_idx"]
@@ -3384,7 +3385,8 @@
               "offset": {
                 "title": "Offset",
                 "description": "offset of this property within the struct",
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               }
             }
           }
@@ -3676,17 +3678,20 @@
           "l1_gas": {
             "title": "L1Gas",
             "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "l1_data_gas": {
             "title": "L1DataGas",
             "description": "data gas consumed by this transaction, 0 if blobs are not used",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "l2_gas": {
             "title": "L2Gas",
             "description": "l2 gas consumed by this transaction, used for computation and calldata",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": ["l1_gas", "l1_data_gas", "l2_gas"]
@@ -3723,12 +3728,13 @@
         "description": "represents a path to the highest non-zero descendant node",
         "properties": {
           "path": {
-            "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant (bounded by 2^251)",
+            "description": "an unsigned integer whose binary representation represents the path from the current node to its highest non-zero descendant (bounded by 2^251)",
             "$ref": "#/components/schemas/NUM_AS_HEX"
           },
           "length": {
             "description": "the length of the path (bounded by 251)",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "child": {
             "description": "the hash of the unique non-zero maximal-height descendant node",
@@ -3859,7 +3865,8 @@
             "transaction_index": {
               "title": "Transaction index",
               "description": "The index of the first transaction failing in a sequence of given transactions",
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             "execution_error": {
               "title": "revert error",

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -47,7 +47,7 @@
             },
             {
               "title": "Pending block with transaction hashes",
-              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TX_HASHES"
+              "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_WITH_TX_HASHES"
             }
           ]
         }
@@ -84,7 +84,7 @@
             },
             {
               "title": "Pending block with transactions",
-              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TXS"
+              "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_WITH_TXS"
             }
           ]
         }
@@ -121,7 +121,7 @@
             },
             {
               "title": "Pending block with transactions",
-              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_RECEIPTS"
+              "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_WITH_RECEIPTS"
             }
           ]
         }
@@ -158,7 +158,7 @@
             },
             {
               "title": "Pending state update",
-              "$ref": "#/components/schemas/PENDING_STATE_UPDATE"
+              "$ref": "#/components/schemas/PRE_CONFIRMED_STATE_UPDATE"
             }
           ]
         }
@@ -1223,7 +1223,7 @@
         "title": "Block tag",
         "type": "string",
         "description": "A tag specifying a dynamic reference to a block",
-        "enum": ["latest", "pending"]
+        "enum": ["latest", "pre_confirmed"]
       },
       "SYNC_STATUS": {
         "title": "Sync status",
@@ -1395,7 +1395,7 @@
           "nonces"
         ]
       },
-      "PENDING_STATE_UPDATE": {
+      "PRE_CONFIRMED_STATE_UPDATE": {
         "title": "Pending state update",
         "description": "Pending state update",
         "type": "object",
@@ -1616,7 +1616,7 @@
           "starknet_version"
         ]
       },
-      "PENDING_BLOCK_HEADER": {
+      "PRE_CONFIRMED_BLOCK_HEADER": {
         "title": "Pending block header",
         "type": "object",
         "properties": {
@@ -1752,7 +1752,7 @@
           }
         ]
       },
-      "PENDING_BLOCK_WITH_TX_HASHES": {
+      "PRE_CONFIRMED_BLOCK_WITH_TX_HASHES": {
         "title": "Pending block with transaction hashes",
         "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
         "allOf": [
@@ -1762,11 +1762,11 @@
           },
           {
             "title": "Pending block header",
-            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+            "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_HEADER"
           }
         ]
       },
-      "PENDING_BLOCK_WITH_TXS": {
+      "PRE_CONFIRMED_BLOCK_WITH_TXS": {
         "title": "Pending block with transactions",
         "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
         "allOf": [
@@ -1776,11 +1776,11 @@
           },
           {
             "title": "Pending block header",
-            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+            "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_HEADER"
           }
         ]
       },
-      "PENDING_BLOCK_WITH_RECEIPTS": {
+      "PRE_CONFIRMED_BLOCK_WITH_RECEIPTS": {
         "title": "Pending block with transactions and receipts",
         "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
         "allOf": [
@@ -1790,7 +1790,7 @@
           },
           {
             "title": "Pending block header",
-            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+            "$ref": "#/components/schemas/PRE_CONFIRMED_BLOCK_HEADER"
           }
         ]
       },
@@ -3107,9 +3107,8 @@
         "type": "string",
         "enum": [
           "RECEIVED",
-          "REJECTED",
+          "CANDIDATE",
           "PRE_CONFIRMED",
-          "EXECUTED",
           "ACCEPTED_ON_L2",
           "ACCEPTED_ON_L1"
         ],
@@ -3118,7 +3117,7 @@
       "TXN_FINALITY_STATUS": {
         "title": "Finality status",
         "type": "string",
-        "enum": ["EXECUTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": ["PRE_CONFIRMED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The finality status of the transaction"
       },
       "TXN_EXECUTION_STATUS": {
@@ -3136,7 +3135,7 @@
       "BLOCK_STATUS": {
         "title": "Block status",
         "type": "string",
-        "enum": ["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"],
+        "enum": ["PRE_CONFIRMED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"],
         "description": "The status of the block"
       },
       "FUNCTION_CALL": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3105,7 +3105,14 @@
       "TXN_STATUS": {
         "title": "Transaction status",
         "type": "string",
-        "enum": ["RECEIVED", "REJECTED", "PRE_CONFIRMED", "EXECUTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": [
+          "RECEIVED",
+          "REJECTED",
+          "PRE_CONFIRMED",
+          "EXECUTED",
+          "ACCEPTED_ON_L2",
+          "ACCEPTED_ON_L1"
+        ],
         "description": "The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase"
       },
       "TXN_FINALITY_STATUS": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3105,13 +3105,13 @@
       "TXN_STATUS": {
         "title": "Transaction status",
         "type": "string",
-        "enum": ["RECEIVED", "REJECTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": ["RECEIVED", "REJECTED", "PRE_CONFIRMED", "EXECUTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase"
       },
       "TXN_FINALITY_STATUS": {
         "title": "Finality status",
         "type": "string",
-        "enum": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "enum": ["EXECUTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
         "description": "The finality status of the transaction"
       },
       "TXN_EXECUTION_STATUS": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -650,7 +650,7 @@
       ],
       "result": {
         "name": "result",
-        "description": "the fee estimations",
+        "description": "The fee estimations",
         "schema": {
           "title": "Estimation",
           "type": "array",
@@ -694,9 +694,9 @@
       ],
       "result": {
         "name": "result",
-        "description": "the fee estimation",
+        "description": "The fee estimation",
         "schema": {
-          "$ref": "#/components/schemas/FEE_ESTIMATE"
+          "$ref": "#/components/schemas/MESSAGE_FEE_ESTIMATE"
         }
       },
       "errors": [
@@ -3481,13 +3481,30 @@
         "enum": ["SKIP_VALIDATE"],
         "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally"
       },
-      "PRICE_UNIT": {
-        "title": "price unit",
+      "PRICE_UNIT_WEI": {
+        "title": "Price unit wei",
         "type": "string",
-        "enum": ["WEI", "FRI"]
+        "enum": ["WEI"]
       },
-      "FEE_ESTIMATE": {
-        "title": "Fee estimation",
+      "PRICE_UNIT_FRI": {
+        "title": "Price unit fri",
+        "type": "string",
+        "enum": ["FRI"]
+      },
+      "PRICE_UNIT": {
+        "title": "Price unit",
+        "description": "Units in which the fee is given",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PRICE_UNIT_WEI"
+          },
+          {
+            "$ref": "#/components/schemas/PRICE_UNIT_FRI"
+          }
+        ]
+      },
+      "FEE_ESTIMATE_COMMON": {
+        "title": "Fee estimation common fields",
         "type": "object",
         "properties": {
           "l1_gas_consumed": {
@@ -3524,11 +3541,6 @@
             "title": "Overall fee",
             "description": "The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to l1_gas_consumed*l1_gas_price + l1_data_gas_consumed*l1_data_gas_price + l2_gas_consumed*l2_gas_price",
             "$ref": "#/components/schemas/u128"
-          },
-          "unit": {
-            "title": "Fee unit",
-            "description": "units in which the fee is given",
-            "$ref": "#/components/schemas/PRICE_UNIT"
           }
         },
         "required": [
@@ -3538,8 +3550,45 @@
           "l2_gas_price",
           "l1_data_gas_consumed",
           "l1_data_gas_price",
-          "overall_fee",
-          "unit"
+          "overall_fee"
+        ]
+      },
+      "FEE_ESTIMATE": {
+        "title": "Fee estimation",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FEE_ESTIMATE_COMMON"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "unit": {
+                "title": "Fee unit",
+                "description": "Units in which the fee is given, can only be FRI",
+                "$ref": "#/components/schemas/PRICE_UNIT_FRI"
+              }
+            },
+            "required": ["unit"]
+          }
+        ]
+      },
+      "MESSAGE_FEE_ESTIMATE": {
+        "title": "Message fee estimation",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FEE_ESTIMATE_COMMON"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "unit": {
+                "title": "Fee unit",
+                "description": "Units in which the fee is given, can only be WEI",
+                "$ref": "#/components/schemas/PRICE_UNIT_WEI"
+              }
+            },
+            "required": ["unit"]
+          }
         ]
       },
       "FEE_PAYMENT": {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1620,10 +1620,10 @@
         "title": "Pending block header",
         "type": "object",
         "properties": {
-          "parent_hash": {
-            "title": "Parent hash",
-            "description": "The hash of this block's parent",
-            "$ref": "#/components/schemas/BLOCK_HASH"
+          "block_number": {
+            "description": "The block number of the block that the proposer is currently building. Note that this is a local view of the node, whose accuracy depends on its polling interval length.",
+            "title": "Block number",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
           },
           "timestamp": {
             "title": "Timestamp",
@@ -1664,7 +1664,7 @@
           }
         },
         "required": [
-          "parent_hash",
+          "block_number",
           "timestamp",
           "sequencer_address",
           "l1_gas_price",
@@ -1674,7 +1674,7 @@
           "starknet_version"
         ],
         "not": {
-          "required": ["block_hash", "block_number", "new_root"]
+          "required": ["block_hash", "new_root"]
         }
       },
       "BLOCK_WITH_TX_HASHES": {

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -93,7 +93,8 @@
               "items": {
                 "oneOf": [
                   {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   {
                     "type": "array",
@@ -111,7 +112,8 @@
             "type": "array",
             "description": "a list of sizes of segments in the bytecode, each segment is hashed individually when computing the bytecode hash",
             "items": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             }
           }
         },
@@ -129,7 +131,8 @@
           "offset": {
             "title": "Offset",
             "description": "The offset of the entry point in the program",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "selector": {
             "title": "Selector",
@@ -154,7 +157,8 @@
             "enum": ["AP", "FP"]
           },
           "offset": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": ["register", "offset"]
@@ -182,7 +186,8 @@
                   "$ref": "#/components/schemas/CellRef"
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 }
               ]
             },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -401,7 +401,8 @@
               "order": {
                 "title": "order",
                 "description": "the order of the event within the transaction",
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               }
             }
           },
@@ -421,7 +422,8 @@
               "order": {
                 "title": "order",
                 "description": "the order of the message within the transaction",
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               }
             }
           },
@@ -438,12 +440,14 @@
           "l1_gas": {
             "title": "L1Gas",
             "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "l2_gas": {
             "title": "L2Gas",
             "description": "l2 gas consumed by this transaction, used for computation and calldata",
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": ["l1_gas", "l2_gas"]

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -45,6 +45,12 @@
           "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
         },
         {
+          "$ref": "#/components/errors/REPLACEMENT_TRANSACTION_UNDERPRICED"
+        },
+        {
+          "$ref": "#/components/errors/FEE_BELOW_MINIMUM"
+        },
+        {
           "$ref": "#/components/errors/VALIDATION_FAILURE"
         },
         {
@@ -113,6 +119,12 @@
           "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
         },
         {
+          "$ref": "#/components/errors/REPLACEMENT_TRANSACTION_UNDERPRICED"
+        },
+        {
+          "$ref": "#/components/errors/FEE_BELOW_MINIMUM"
+        },
+        {
           "$ref": "#/components/errors/VALIDATION_FAILURE"
         },
         {
@@ -177,6 +189,12 @@
           "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
         },
         {
+          "$ref": "#/components/errors/REPLACEMENT_TRANSACTION_UNDERPRICED"
+        },
+        {
+          "$ref": "#/components/errors/FEE_BELOW_MINIMUM"
+        },
+        {
           "$ref": "#/components/errors/VALIDATION_FAILURE"
         },
         {
@@ -232,7 +250,8 @@
       },
       "INVALID_TRANSACTION_NONCE": {
         "code": 52,
-        "message": "Invalid transaction nonce"
+        "message": "Invalid transaction nonce",
+        "data": "Invalid transaction nonce of contract at address <ADDRESS>. Account nonce: <NONCE>; got: <PAYLOAD_NONCE>."
       },
       "INSUFFICIENT_RESOURCES_FOR_VALIDATE": {
         "code": 53,
@@ -280,6 +299,14 @@
         "code": 63,
         "message": "An unexpected error occurred",
         "data": "string"
+      },
+      "REPLACEMENT_TRANSACTION_UNDERPRICED": {
+        "code": 64,
+        "message": "Replacement transaction is underpriced"
+      },
+      "FEE_BELOW_MINIMUM": {
+        "code": 65,
+        "message": "Transaction fee below minimum"
       }
     }
   }

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.8.1",
+    "version": "0.9.0-rc.0",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },


### PR DESCRIPTION
## Changes

Remove parent hash and add block number to `pre_confirmed_block_header`. The parent hash is removed because a pre-confirmed block may be produced while the thread computing the previous height's commitments hasn't concluded.


## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [ ] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
