### PR TITLE
Remove block-level tracing on pre_confirmed

### DIFF
--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -114,7 +114,16 @@
           "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/BLOCK_ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BLOCK_ID"
+              },
+              {
+                "not": {
+                  "enum": ["pre_confirmed"]
+                }
+              }
+            ]
           }
         }
       ],


### PR DESCRIPTION
## Changes

This is because there may be newly declared classes present in the pre-confirmed block, which the node doesn't have the code for. Regarding other execution-based endpoints of the RPC:
1. Tracing on a single transaction with `PRE_CONFIRMED` or `CANDIDATE`, will return error `NO_TRACE_AVAILABLE`
2. Requests to `call`, `simulateTransactions`, `estimateFee`, `estimateMessageFee` with block_id = pre_confirmed will return a `TRANSACTION_EXECUTION_ERROR` if they need to run a newly declared class which only appears in the pre-confirmed block.

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [ ] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
