### PR TITLE
fix: allow `PRE_CONFIRMED` status in `starknet_getMessagesStatus` response

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -282,7 +282,7 @@
                   },
                   {
                     "not": {
-                      "enum": ["RECEIVED", "CANDIDATE", "PRE_CONFIRMED"]
+                      "enum": ["RECEIVED", "CANDIDATE"]
                     }
                   }
                 ]


### PR DESCRIPTION
The correct transaction status for L1 handler transactions in the pre-confirmed block is `PRE_CONFIRMED`, so we should allow that value.