### PR TITLE
Update `starknet_getMessagesStatus` to use `TXN_FINALITY_STATUS`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -276,16 +276,7 @@
               },
               "finality_status": {
                 "title": "finality status",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/TXN_STATUS"
-                  },
-                  {
-                    "not": {
-                      "enum": ["RECEIVED", "CANDIDATE"]
-                    }
-                  }
-                ]
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
               },
               "execution_status": {
                 "title": "execution status",


### PR DESCRIPTION
## Changes

Update `starknet_getMessagesStatus` to use `TXN_FINALITY_STATUS` type in the `finality_status` field since they have the same values.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
