### PR TITLE
Remove redundant not in requirement specification

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1680,10 +1680,7 @@
           "l1_data_gas_price",
           "l1_da_mode",
           "starknet_version"
-        ],
-        "not": {
-          "required": ["block_hash", "new_root"]
-        }
+        ]
       },
       "BLOCK_WITH_TX_HASHES": {
         "title": "Block with transaction hashes",


### PR DESCRIPTION
## Changes

What the title says. I don't see a point in specifying both "required` and "not required`.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] If making a new release, checked out [the guidelines](../api/release.md)
