### PR TITLE
Add `l1_accepted` block tag

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1230,8 +1230,8 @@
       "BLOCK_TAG": {
         "title": "Block tag",
         "type": "string",
-        "description": "A tag specifying a dynamic reference to a block",
-        "enum": ["latest", "pre_confirmed"]
+        "description": "A tag specifying a dynamic reference to a block. Tag `l1_accepted` refers to the latest Starknet block which was included in a state update on L1 and finalized by the consensus on L1. Tag `latest` refers to the latest Starknet block finalized by the consensus on L2. Tag `pre_confirmed` refers to the block which is currently being built by the block proposer in height `latest` + 1.",
+        "enum": ["l1_accepted", "latest", "pre_confirmed"]
       },
       "SYNC_STATUS": {
         "title": "Sync status",


### PR DESCRIPTION
## Changes

Add `l1_accepted` block tag. This tag refers to the latest Starknet block which is included in a state update on L1 and finalized by the consensus on L1.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
