### PR TITLE
fix: invalid extra comma in json spec

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3143,7 +3143,7 @@
         "enum": [
           "PRE_CONFIRMED",
           "ACCEPTED_ON_L2",
-          "ACCEPTED_ON_L1",
+          "ACCEPTED_ON_L1"
         ],
         "description": "The status of the block"
       },


### PR DESCRIPTION
## Changes

Fix an invalid extra comma in the json spec. The `npm run validate_all` command was returning errors due to this.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review