### PR TITLE
Add finality status to receipts

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1104,13 +1104,18 @@
                 "description": "The number of the block in which the event was emitted",
                 "$ref": "#/components/schemas/BLOCK_NUMBER"
               },
+              "finality_status": {
+                "title": "Finality status",
+                "description": "Finality status of the transaction which emitted the event",
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+              },
               "transaction_hash": {
                 "title": "Transaction hash",
                 "description": "The transaction that emitted the event",
                 "$ref": "#/components/schemas/TXN_HASH"
               }
             },
-            "required": ["transaction_hash"]
+            "required": ["transaction_hash", "finality_status"]
           }
         ]
       },


### PR DESCRIPTION
## Changes

It would be cool to return the finality status when returning events in `starknet_getEvents`. In fact, I think it's really necessary, otherwise consumers of the jsonrpc API cannot know, when using getEvents for pre-confirmed whether a block is pre-confirmed or confirmed on l2.
In addition, the info about whether the event is on L1 is really nice as well, although if the added complexity in the node implementation is too much, `is_preconfirmed: bool` replacing this finality status would be sufficient as well.
This also affects websocket subscriptions in https://github.com/starkware-libs/starknet-specs/pull/323 - in fact, this is also very useful for the websocket API since it allows you to handle duplicated events properly.

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)

(i'm using the github interface for these spec PRs, should I really clone the repo on my machine to test it there and check this checklist?)