### PR TITLE
Add transaction_index to getTransactionReceipt and getEvents

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -387,8 +387,8 @@
       "result": {
         "name": "result",
         "schema": {
-          "title": "Transaction receipt with block info",
-          "$ref": "#/components/schemas/TXN_RECEIPT_WITH_BLOCK_INFO"
+          "title": "Transaction receipt with info",
+          "$ref": "#/components/schemas/TXN_RECEIPT_WITH_INFO"
         }
       },
       "errors": [
@@ -1103,6 +1103,12 @@
                 "title": "Block number",
                 "description": "The number of the block in which the event was emitted",
                 "$ref": "#/components/schemas/BLOCK_NUMBER"
+              },
+              "transaction_index": {
+                "title": "Transaction index",
+                "description": "Index of the transaction within the block which emitted this event",
+                "type": "integer",
+                "minimum": 0
               },
               "transaction_hash": {
                 "title": "Transaction hash",
@@ -3004,7 +3010,7 @@
           }
         ]
       },
-      "TXN_RECEIPT_WITH_BLOCK_INFO": {
+      "TXN_RECEIPT_WITH_INFO": {
         "title": "Transaction receipt with block info",
         "allOf": [
           {
@@ -3023,8 +3029,15 @@
                 "title": "Block number",
                 "$ref": "#/components/schemas/BLOCK_NUMBER",
                 "description": "If this field is missing, it means the receipt belongs to the pre-confirmed block"
-              }
-            }
+              },
+              "transaction_index": {
+                "title": "Transaction index",
+                "description": "Index of the transaction corresponding to this receipt",
+                "type": "integer",
+                "minimum": 0
+              },
+            },
+            "required": ["transaction_index"]
           }
         ]
       },

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -3011,7 +3011,7 @@
         ]
       },
       "TXN_RECEIPT_WITH_INFO": {
-        "title": "Transaction receipt with block info",
+        "title": "Transaction receipt with info",
         "allOf": [
           {
             "title": "Transaction receipt",
@@ -3032,7 +3032,7 @@
               },
               "transaction_index": {
                 "title": "Transaction index",
-                "description": "Index of the transaction corresponding to this receipt",
+                "description": "Index of the transaction corresponding to this receipt within the block",
                 "type": "integer",
                 "minimum": 0
               },

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1116,7 +1116,7 @@
                 "$ref": "#/components/schemas/TXN_HASH"
               }
             },
-            "required": ["transaction_hash"]
+            "required": ["transaction_hash", "transaction_index"]
           }
         ]
       },


### PR DESCRIPTION
## Changes

This was proposed by @kkovaacs, but I added the field to getTransactionReceipt too instead of just getEvents.
Related to #326 (which adds finality_status to the same types) and #325 (which fixed block_number in the same types)
Affects #323 

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)

(i'm using the github interface for these spec PRs, should I really clone the repo on my machine to test it there and check this checklist?)