### PR TITLE
Rc3 params fix

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -132,7 +132,14 @@
                 "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EMITTED_EVENT"
               },
               {
-                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+                "type": "object",
+                "properties": {
+                  "finality_status": {
+                    "description": "Finality status of the transaction",
+                    "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+                  }
+                },
+                "required": ["finality_status"]
               }
             ]
           }


### PR DESCRIPTION
## Changes

starknet_subscriptionEvents result params specify a union of object and string value that should be a key-value pair.

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [ ] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
