### PR TITLE
Fix TXN_FINALITY_STATUS reference in starknet_ws_api.json

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -136,7 +136,7 @@
                 "properties": {
                   "finality_status": {
                     "description": "Finality status of the transaction",
-                    "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+                    "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_FINALITY_STATUS"
                   }
                 },
                 "required": ["finality_status"]


### PR DESCRIPTION
## Changes

The `TXN_FINALITY_STATUS` structure is not defined in the file where it is referenced.

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
