### PR TITLE
fix: allow `CONTRACT_NOT_FOUND` error for `starknet_estimateMessageFee`

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -670,6 +670,9 @@
       },
       "errors": [
         {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
           "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
         },
         {

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -709,6 +709,9 @@
       },
       "errors": [
         {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
           "$ref": "#/components/errors/CONTRACT_ERROR"
         },
         {


### PR DESCRIPTION
## Changes

pathfinder currently returns `CONTRACT_NOT_FOUND` if `starknet_estimateMessageFee` is called with an invalid 
`MSG_FROM_L1.to_address` (see https://github.com/eqlabs/pathfinder/issues/2953 ), which seems semantically correct and useful to distinguish from `CONTRACT_ERROR` (see https://github.com/eqlabs/pathfinder/blob/main/crates/rpc/src/method/estimate_message_fee.rs#L102) but technically isn't allowed.