### PR TITLE
fix: param type of storage_keys

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -949,7 +949,7 @@
                 "storage_keys": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FELT"
+                    "$ref": "#/components/schemas/STORAGE_KEY"
                   }
                 }
               },


### PR DESCRIPTION
## Changes
starknet_getStorageProof using STORAGE_KEY instead of FELT

https://github.com/starkware-libs/starknet-specs/issues/259
## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] If making a new release, checked out [the guidelines](../api/release.md)
