### PR TITLE
Allow address filter in `starknet_getEvents` to accept array of addre…

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1203,7 +1203,20 @@
           },
           "address": {
             "title": "from contract",
-            "$ref": "#/components/schemas/ADDRESS"
+            "description": "A contract address or a list of addresses from which events should originate",
+            "oneOf": [
+              {
+                "title": "Single address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              {
+                "title": "List of addresses",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ADDRESS"
+                }
+              }
+            ]
           },
           "keys": {
             "title": "event keys",


### PR DESCRIPTION
The `EVENT_FILTER` schema now accepts either a single address or an array of addresses, matching `eth_getLogs` behavior.

Closes https://github.com/starkware-libs/starknet-specs/issues/348

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)
