### PR TITLE
Revert "fix: allow `CONTRACT_NOT_FOUND` error for `starknet_estimateMessageFee`"

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -670,9 +670,6 @@
       },
       "errors": [
         {
-          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
-        },
-        {
           "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
         },
         {
@@ -711,9 +708,6 @@
         }
       },
       "errors": [
-        {
-          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
-        },
         {
           "$ref": "#/components/errors/CONTRACT_ERROR"
         },


### PR DESCRIPTION
Context of the PR. Some messages I sent on Slack:

The `CONTRACT_NOT_FOUND` error is currently returned by these methods:
- `starknet_call` (has `contract_address` param in the fn_call)
- `starknet_estimateFee`
- `starknet_estimateMessageFee`
- `starknet_getClassHashAt` (has `contract_address` param)
- `starknet_getClassAt` (has `contract_address` param)
- `starknet_getNonce` (has `contract_address` param)
- `starknet_getStorageAt` (has `contract_address` param)

The methods that contain the contract_address param are easy to understand; there's only a single point of cause for a contract to be "not found":  the contract_address contract. But what about `starknet_estimateFee` and `starknet_estimateMessageFee`? How to know when to return the `CONTRACT_NOT_FOUND` error?
Should it be when the sender address wasn't found? Or the contract specified in the calldata? Or when doing an inner call to another contract that wasn't found (also important in the starknet_call method)?

---

IMHO, for this case, we don't need to add a new error type. All the cases are being addressed through the current errors in both starknet_estimateFee and starknet_estimateMessageFee methods. For e.g., in the starknet_estimateFee:
- we already have the default json-rpc [errors](https://www.jsonrpc.org/specification#error_object) for general cases
- invalid block id? `BLOCK_NOT_FOUND` or `-32602	Invalid params`
- invalid simulation_flags? `-32602	Invalid params`
- for the txns, since the json was already validated, makes sense for me to return every error as a `TRANSACTION_EXECUTION_ERROR` since it was found while executing the given txn. Invalid sender address? return `TRANSACTION_EXECUTION_ERROR` specifying it. Invalid signature? `TRANSACTION_EXECUTION_ERROR`. Invalid sender address in an inner call? `TRANSACTION_EXECUTION_ERROR` handle inner call cases with the inner  `CONTRACT_EXECUTION_ERROR_INNER` type (same for the `starknet_estimateMessageFee` method, as we have the `CONTRACT_ERROR` type.

If we try to create custom errors for every field, we will end up with too many error types (like `SENDER_ADDRESS_NOT_FOUND`, `INVALID_NONCE`, `INVALID_TXN_TYPE`, `INVALID_L1_ADDRESS`, etc...), not to mention some of them would have to support inner calls like the `CONTRACT_EXECUTION_ERROR_INNER`, since they could be triggered on it.
Therefore, I believe we should just remove the `CONTRACT_NOT_FOUND` error from these methods.
Differently from methods like `starknet_getClassHashAt`, which has a specific `contract_address` parameter, every occurrence of a contract address in these methods is through inner parameters (inside the `BROADCASTED_TXN` array in the `starknet_estimateFee`, and inside the `MSG_FROM_L1` in the `starknet_estimateMessageFee`). Why return a specific error for a single inner parameter, and not for the others?