### PR TITLE
Allow address filter in `starknet_subscribeEvents` to accept array of addresses

### DIFF
--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -63,9 +63,22 @@
         {
           "name": "from_address",
           "summary": "Filter events by from_address which emitted the event",
+          "description": "A contract address or a list of addresses from which events should originate",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/ADDRESS"
+            "oneOf": [
+              {
+                "title": "Single address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              {
+                "title": "List of addresses",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ADDRESS"
+                }
+              }
+            ]
           }
         },
         {


### PR DESCRIPTION
## Changes

Similar to https://github.com/starkware-libs/starknet-specs/pull/351 , allow single address or list of addresses in websocket method `starknet_subscribeEvents`.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)

## Question                                                                                                                                                                                 
                                                                                                                                                                                              
Should we add the `TOO_MANY_ADDRESSES_IN_FILTER` to the errors for this method? I noticed `starknet_getEvents` doesn't have it, but `starknet_subscribeNewTransactionReceipts` and  `starknet_subscribeNewTransactions` do include it for their array address filters.