### PR TITLE
Update proof pattern regex in OpenRPC JSON

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -2393,7 +2393,7 @@
                 "title": "Proof",
                 "description": "Optional proof for the transaction, encoded as a base64 string of big-endian packed u32 values",
                 "type": "string",
-                "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
+                "pattern": "^(?:[A-Za-z0-9+/]{16})*(?:[A-Za-z0-9+/]{5}[AQgw]==|[A-Za-z0-9+/]{10}[AEIMQUYcgkosw048]=)?$"
               }
             }
           }


### PR DESCRIPTION
Pattern is too permissive to be decoded as u32 array. For example,  string `TX==` matches existing pattern, but it is not decodable as single `u32`, let alone as an array.

## Changes

Changed regex to be stricter. I think I got it right, but double check is still necessary. 
## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [x] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)
