### PR TITLE
feat(wallet-api): add STRK20 privacy protocol methods

### DIFF
--- a/docs/plans/2026-04-13-strk20-wallet-api-decisions.md
+++ b/docs/plans/2026-04-13-strk20-wallet-api-decisions.md
@@ -1,0 +1,92 @@
+# STRK20 Wallet API — Design Decisions
+
+Working notes for a new wallet API covering the STRK20 privacy protocol. Captures decisions made during brainstorming; open questions are flagged at the end.
+
+## Method naming
+
+- Use the `wallet_strk20*` prefix (named after the STRK20 privacy protocol, not generic "private").
+- `wallet_strk20InvokeTransaction` — submit actions (mirrors `wallet_addInvokeTransaction`).
+- `wallet_strk20Balances` — query balances for a list of token addresses.
+- `wallet_strk20Mode` — query whether the address returned by `wallet_requestAccounts` is real or a generated random one.
+
+Rejected alternatives:
+
+- A single `wallet_strk20` method with multi-purpose params. Reads and writes should be separate: different return types, different error semantics.
+- Per-action methods (`wallet_strk20Deposit`, `wallet_strk20Withdraw`, ...). API bloat; 1–2 actions fit fine in an array.
+- A client-side builder pattern. Adds complexity without benefit given small action counts.
+
+## Action shape
+
+Flat array of action objects, not grouped-by-token. Most calls have 1–2 actions, and a flat array matches the existing `wallet_addInvokeTransaction` pattern.
+
+Example:
+
+```json
+[
+  { "type": "withdraw", "token": "0x...", "amount": 10, "recipient": "0x..." },
+  { "type": "transfer", "token": "0x...", "amount": 11, "recipient": "0x..." }
+]
+```
+
+## Action types (v1 scope)
+
+- **deposit** — `{ type, token, amount }`. Always to self (no `recipient` field; can be added later).
+- **withdraw** — `{ type, token, amount, recipient }`. `recipient` always explicit (no default-to-self).
+- **transfer** — `{ type, token, amount, recipient }`. Private transfer to another user.
+- **invoke / swap** — **deferred** to a later version. Needs cross-referencing (placeholders for open note IDs, pool address) between actions, which adds significant complexity. Deposit + withdraw + transfer cover the core privacy use cases.
+
+## Registration
+
+Handled transparently by the wallet — no explicit `register` action. If the user isn't registered, the wallet returns a `NOT_REGISTERED` error telling them to register first and come back.
+
+## Return type
+
+`wallet_strk20InvokeTransaction` returns `{ transaction_hash }`, same as `wallet_addInvokeTransaction`.
+
+The dapp must tolerate long-running calls — proof generation takes time. No special async mechanism is introduced; the RPC call just takes longer than a normal transaction submission.
+
+## Privacy mode and address handling
+
+- No explicit mode-setter method.
+- When a dapp calls `wallet_requestAccounts`, the wallet asks the user whether to return the real address or a freshly generated one.
+- `wallet_strk20Mode` is read-only — it lets the dapp know whether the current address is real or generated, so the UI can adapt (e.g. show a "private mode" indicator).
+- If the real address was already shared and the dapp then calls `wallet_strk20InvokeTransaction`, the wallet warns the user but doesn't block — they may still want to use private transfers even with reduced privacy.
+
+## Non-privacy-aware dapp flow
+
+A key goal: existing dapps (e.g. a DEX) should work with privacy without knowing about STRK20 at all.
+
+Flow:
+
+1. The dapp calls `wallet_requestAccounts` as usual.
+2. The wallet generates a fresh address and offers to fund it by withdrawing from the privacy pool.
+3. The user interacts with the dapp normally — public transactions from the generated address via `wallet_addInvokeTransaction`.
+4. When the session ends, the wallet offers to sweep leftover funds back into the privacy pool.
+
+The dapp does nothing special. All the privacy mechanics live in the wallet UI.
+
+## ERC20 handling
+
+Tokens are referenced by address only (type `ADDRESS` / `FELT`). No need for the `ASSET` structure used by `wallet_watchAsset` — the privacy pool contract handles token interaction internally.
+
+## Errors
+
+Tentative set:
+
+New:
+
+- `NOT_REGISTERED` — user hasn't registered in the privacy pool.
+- `INSUFFICIENT_PRIVATE_BALANCE` — not enough tokens for withdraw/transfer.
+- `PRIVACY_LEAK` — wallet detected that privacy may be compromised (shape and covered cases still open).
+
+Reused from existing wallet spec:
+
+- `USER_REFUSED_OP` (113) — user rejected in wallet UI.
+- `INVALID_REQUEST_PAYLOAD` — malformed actions.
+- `API_VERSION_NOT_SUPPORTED`.
+
+## Open questions
+
+1. Should the non-privacy-aware dapp fund/sweep flow have spec-level support (e.g. a session-done signal that triggers the sweep prompt), or stay entirely in wallet UI?
+2. Should recipient-not-registered and channel-not-setup be explicit errors, or handled transparently by the wallet auto-setting up channels?
+3. Exact shape of the `PRIVACY_LEAK` error and what cases it covers.

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -446,6 +446,122 @@
       ]
     },
     {
+      "name": "wallet_strk20InvokeTransaction",
+      "summary": "Submit a transaction containing STRK20 privacy protocol actions",
+      "description": "Submits one or more STRK20 actions (deposit, withdraw, private transfer) as a single transaction. The wallet displays an approval UI and may take significantly longer than wallet_addInvokeTransaction because zero-knowledge proof generation is required. The dapp must tolerate long-running calls. Registration into the privacy pool is handled transparently by the wallet — if the user is not registered, NOT_REGISTERED is returned.",
+      "params": [
+        {
+          "name": "actions",
+          "description": "An ordered list of STRK20 actions to execute atomically",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/STRK20_ACTION"
+            },
+            "minItems": 1
+          }
+        },
+        {
+          "name": "api_version",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/API_VERSION"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "Transaction Hash",
+              "$ref": "#/components/schemas/PADDED_TXN_HASH"
+            }
+          },
+          "required": ["transaction_hash"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NOT_REGISTERED"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_PRIVATE_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/PRIVACY_LEAK"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+        },
+        {
+          "$ref": "#/components/errors/USER_REFUSED_OP"
+        },
+        {
+          "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+        },
+        {
+          "$ref": "#/components/errors/UNKNOWN_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "wallet_strk20Balances",
+      "summary": "Query the user's private balances for a list of tokens",
+      "description": "Returns the private balance held inside the STRK20 privacy pool for each of the requested token addresses. If the user is not registered in the pool, returns NOT_REGISTERED.",
+      "params": [
+        {
+          "name": "tokens",
+          "description": "The token addresses to query balances for",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            },
+            "minItems": 1
+          }
+        },
+        {
+          "name": "api_version",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/API_VERSION"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "Private balances, one entry per requested token, in the same order as the input",
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/STRK20_BALANCE_ENTRY"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NOT_REGISTERED"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+        },
+        {
+          "$ref": "#/components/errors/USER_REFUSED_OP"
+        },
+        {
+          "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+        },
+        {
+          "$ref": "#/components/errors/UNKNOWN_ERROR"
+        }
+      ]
+    },
+    {
       "name": "wallet_signTypedData",
       "summary": "Sign typed data using the wallet",
       "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display sign-typed-data UI.",
@@ -834,6 +950,155 @@
           }
         }
       },
+      "STRK20_ACTION": {
+        "title": "STRK20 Action",
+        "description": "A single action to perform via the STRK20 privacy protocol. The 'type' field discriminates the variant.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/STRK20_DEPOSIT_ACTION"
+          },
+          {
+            "$ref": "#/components/schemas/STRK20_WITHDRAW_ACTION"
+          },
+          {
+            "$ref": "#/components/schemas/STRK20_TRANSFER_ACTION"
+          },
+          {
+            "$ref": "#/components/schemas/STRK20_INVOKE_ACTION"
+          }
+        ]
+      },
+      "STRK20_DEPOSIT_ACTION": {
+        "title": "STRK20 Deposit Action",
+        "description": "Deposits public funds from the user's account into the privacy pool. Always to self.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["deposit"]
+          },
+          "token": {
+            "title": "Token Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "amount": {
+            "title": "Amount",
+            "description": "Amount of the token, in its smallest unit",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["type", "token", "amount"]
+      },
+      "STRK20_WITHDRAW_ACTION": {
+        "title": "STRK20 Withdraw Action",
+        "description": "Withdraws funds from the privacy pool to a public recipient address.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["withdraw"]
+          },
+          "token": {
+            "title": "Token Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "amount": {
+            "title": "Amount",
+            "description": "Amount of the token, in its smallest unit",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "recipient": {
+            "title": "Recipient Address",
+            "description": "The public Starknet address that receives the withdrawn funds",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        "required": ["type", "token", "amount", "recipient"]
+      },
+      "STRK20_TRANSFER_ACTION": {
+        "title": "STRK20 Transfer Action",
+        "description": "Privately transfers funds inside the privacy pool to another registered user.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["transfer"]
+          },
+          "token": {
+            "title": "Token Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "amount": {
+            "title": "Amount",
+            "description": "Amount of the token, in its smallest unit",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "recipient": {
+            "title": "Recipient Address",
+            "description": "The Starknet address of the registered recipient inside the privacy pool",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        "required": ["type", "token", "amount", "recipient"]
+      },
+      "STRK20_INVOKE_ACTION": {
+        "title": "STRK20 Invoke Action",
+        "description": "Invokes an arbitrary contract entry point as part of the same STRK20 transaction. Calldata items may be literal felts or wallet-resolved placeholders that the wallet substitutes during action assembly: ${openNoteIds[N]} for the Nth opened note ID, or ${poolAddress} for the privacy pool address.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["invoke"]
+          },
+          "contract": {
+            "title": "Contract Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "calldata": {
+            "type": "array",
+            "title": "Calldata",
+            "items": {
+              "$ref": "#/components/schemas/STRK20_CALLDATA_ITEM"
+            }
+          }
+        },
+        "required": ["type", "contract", "calldata"]
+      },
+      "STRK20_CALLDATA_ITEM": {
+        "title": "STRK20 Invoke Calldata Item",
+        "description": "A single calldata entry: either a literal felt, or one of the placeholder strings the wallet expands during action assembly.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FELT"
+          },
+          {
+            "$ref": "#/components/schemas/STRK20_CALLDATA_PLACEHOLDER"
+          }
+        ]
+      },
+      "STRK20_CALLDATA_PLACEHOLDER": {
+        "title": "STRK20 Calldata Placeholder",
+        "description": "A wallet-resolved placeholder that the wallet substitutes with a single felt during action assembly. ${openNoteIds[N]} expands to the Nth note ID created by openNote actions in the same transaction; ${poolAddress} expands to the privacy pool contract address. N is a zero-based index.",
+        "type": "string",
+        "pattern": "^\\$\\{(?:openNoteIds\\[[0-9]+\\]|poolAddress)\\}$"
+      },
+      "STRK20_BALANCE_ENTRY": {
+        "title": "STRK20 Balance Entry",
+        "description": "A private balance for a single token held inside the privacy pool",
+        "type": "object",
+        "properties": {
+          "token": {
+            "title": "Token Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "balance": {
+            "title": "Balance",
+            "description": "The private balance of the token, in its smallest unit",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["token", "balance"]
+      },
       "PADDED_FELT": {
         "type": "string",
         "title": "Padded felt",
@@ -881,6 +1146,21 @@
         "code": 117,
         "message": "An error occurred (CHAIN_ID_NOT_SUPPORTED)",
         "description": "The requested chain ID is not supported by the wallet"
+      },
+      "NOT_REGISTERED": {
+        "code": 118,
+        "message": "An error occurred (NOT_REGISTERED)",
+        "description": "The user is not registered in the STRK20 privacy pool"
+      },
+      "INSUFFICIENT_PRIVATE_BALANCE": {
+        "code": 119,
+        "message": "An error occurred (INSUFFICIENT_PRIVATE_BALANCE)",
+        "description": "The user does not have enough private balance to cover the requested withdraw or transfer"
+      },
+      "PRIVACY_LEAK": {
+        "code": 120,
+        "message": "An error occurred (PRIVACY_LEAK)",
+        "description": "The wallet detected that completing the operation may compromise the user's privacy"
       },
       "API_VERSION_NOT_SUPPORTED": {
         "code": 162,


### PR DESCRIPTION
  ## Summary
  Adds three wallet-API methods for the STRK20 privacy protocol:
  - `wallet_strk20InvokeTransaction` — submit deposit/withdraw/transfer/invoke actions
  - `wallet_strk20Balances` — query private balances per token
  - `wallet_strk20Mode` — report whether the active address is real or generated

  Adds errors `NOT_REGISTERED`, `INSUFFICIENT_PRIVATE_BALANCE`, `PRIVACY_LEAK` and supporting schemas (`STRK20_ACTION` variants, `STRK20_INVOKE_ACTION` with `${openNotes[N]}` / `${withdrawals[N]}` /
  `${poolAddress}` calldata placeholders, `STRK20_BALANCE_ENTRY`, `STRK20_MODE`).
