### PR TITLE
docs: READMEs for api, wallet, proving, and p2p specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,41 @@
-# Starknet Specifications
+# Starknet specifications
 
-This repository publishes different technical specifications pertaining to the implementation and interaction with Starknet.
+This repository publishes technical specifications for Starknet: full-node JSON-RPC, wallet JSON-RPC, transaction proving JSON-RPC, and peer-to-peer protocols for node and sequencer stacks.
 
-## API
+| Area                                      | Details                                 |
+| ----------------------------------------- | --------------------------------------- |
+| [Node JSON-RPC](api/README.md)            | `api/` — OpenRPC documents and releases |
+| [Wallet JSON-RPC](wallet-api/README.md)   | `wallet-api/` — dapp ↔ wallet surface  |
+| [Proving JSON-RPC](proving-api/README.md) | `proving-api/` — transaction prover API |
+| [P2P protocols](p2p/README.md)            | `p2p/` — Protocol Buffers and docs      |
 
-The JSON-RPC API can be found under the `api/` folder.
-You can view it more conveniently using the OpenRPC playground [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false).
+For a high-level comparison between Starknet’s node API and common Ethereum node APIs, see [starknet_vs_ethereum_node_apis.md](./starknet_vs_ethereum_node_apis.md).
 
-A guide to the API can be found [here](./starknet_vs_ethereum_node_apis.md).
+The main read API is easy to browse in the [OpenRPC playground](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false).
 
-## MCP Server (Claude Code)
+## Tooling (Node.js)
 
-An MCP server is available under `mcp/` that exposes all Starknet JSON-RPC methods as Claude Code tools. This lets Claude query blocks, transactions, state, and traces directly from a live Starknet node.
+From the repository root, after installing dependencies:
 
-If you use Claude Code, run `/install-starknet-mcp <your-rpc-url>` from this repo to set it up. See [mcp/README.md](./mcp/README.md) for details.
-
-# Tooling
-
-When developing the schema, you can validate the OpenRPC schema file, by running the provided script.
-Note this requires node.js installed.
-
-The command:
-
-```
-./validate.js api/starknet_api_openrpc.json
+```bash
+npm ci
 ```
 
-will run a validation on the `api/starknet_api_openrpc.json` schema file.
-If everything is ok, an appropriate message is displayed; otherwise errors are output to standard error.
+Validate every OpenRPC document under `api/` (except `starknet_metadata.json`), plus `wallet-api/wallet_rpc.json` and `proving-api/starknet_proving_api_openrpc.json`:
+
+```bash
+npm run validate_all
+```
+
+Additional checks used in CI:
+
+```bash
+npm run check_component_uniqueness
+npm run format_check
+```
+
+Apply formatting with `npm run format` when you change Markdown or JSON that Prettier covers.
+
+## Optional: MCP helper
+
+An MCP server that exposes Starknet JSON-RPC as tools lives under `mcp/`; see [mcp/README.md](./mcp/README.md).

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,34 @@
+# Starknet node API (`api/`)
+
+This directory holds the **Starknet full-node JSON-RPC** specifications and related JSON artifacts used by nodes, indexers, and SDKs.
+
+## Files
+
+| File                              | Role                                                                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `starknet_api_openrpc.json`       | Core read API (blocks, state, classes, events, proofs, etc.).                                                                  |
+| `starknet_write_api.json`         | Write-side methods (merged or referenced with the main document in releases).                                                  |
+| `starknet_trace_api_openrpc.json` | Trace and simulation methods.                                                                                                  |
+| `starknet_ws_api.json`            | WebSocket subscription API.                                                                                                    |
+| `starknet_executables.json`       | Executable / compiler artifact metadata used with the API.                                                                     |
+| `starknet_metadata.json`          | Supplementary metadata (skipped by `validate_all`; not a standalone OpenRPC file in CI).                                       |
+| `release.md`                      | **Release process**: draft → release candidate → recommendation, semver tagging, and synchronized versions across these files. |
+
+## Releases and versioning
+
+All specification JSON files here are versioned **together** as one logical node API release. When you bump the spec, update the `"version"` field in each affected document and align `package.json` as described in `release.md`.
+
+## Validation
+
+From the repository root, `npm run validate_all` validates every `api/*.json` OpenRPC file except `starknet_metadata.json`, and also validates `wallet-api/wallet_rpc.json` and `proving-api/starknet_proving_api_openrpc.json`.
+
+To validate only the main read document:
+
+```bash
+./validate.js api/starknet_api_openrpc.json
+```
+
+## Further reading
+
+- [starknet_vs_ethereum_node_apis.md](../starknet_vs_ethereum_node_apis.md)
+- [Repository overview](../README.md)

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -1,25 +1,37 @@
-# StarkNet P2P Specification
+# Starknet P2P specification (`p2p/`)
 
-This repo contains and tracks the specification of the P2P protocol for StarkNet nodes.
+This tree holds the **peer-to-peer** specification for Starknet nodes: Protocol Buffer (`.proto`) messages and Markdown overviews for sync, mempool, and consensus-related traffic.
 
-## Starknet P2P Networks
+## Starknet P2P networks
 
-There are three different networks that serve different type of applications:
+Three logical networks support different roles:
 
-- [Sync](./p2p/proto/sync/protocols.md) - responsible for downloading information about blocks existing in Starknet
-- [Mempool](./p2p/proto/mempool/mempool.md) - responsible for handling transactions pending for insertion to Starknet
-- [Consensus](./p2p/proto/consensus/consensus.md) - responsible for creating and adding new blocks to Starknet via staking
+- [Sync](proto/sync/protocols.md) — downloading information about existing Starknet blocks.
+- [Mempool](proto/mempool/mempool.md) — transactions pending inclusion.
+- [Consensus](proto/consensus/consensus.md) — producing and agreeing on new blocks (staking).
 
-Each network has a separate discovery network. The Kademlia protocol names for those networks are:
+Each network has a separate Kademlia-style discovery namespace, for example:
 
-- /starknet/<chain_id>/sync/kad/1.0.0
-- /starknet/<chain_id>/mempool/kad/1.0.0
-- /starknet/<chain_id>/consensus/kad/1.0.0
+- `/starknet/<chain_id>/sync/kad/1.0.0`
+- `/starknet/<chain_id>/mempool/kad/1.0.0`
+- `/starknet/<chain_id>/consensus/kad/1.0.0`
 
-A node that wants to connect to multiple networks should connect through a different port for each network.
+A node that joins several networks should use a distinct listen address (port) per network. Splitting by protocol allows different security policies, capability filtering, and modular implementations per subnetwork.
 
-The reasons to split the network by protocols and not have a singular network are:
+## Protocol Buffer sources
 
-- Allow adding custom security policies and authentication requirements for each network separately.
-- Filter out nodes that don't support the capabilities you need
-- Allow modular development of node's code stack by having a node comprised of different implementations for each network.
+`.proto` files live under `p2p/proto/` (imports use paths such as `p2p/proto/common.proto`; compile with `-I` set to the **repository root**).
+
+List every proto file from the repository root:
+
+```bash
+find p2p -name '*.proto' | sort
+```
+
+## CI
+
+GitHub Actions compiles all discovered `.proto` files with `protoc` for Rust, Python, C++, and Go outputs; see [.github/workflows/starknet_p2p_specs_ci.yml](../.github/workflows/starknet_p2p_specs_ci.yml). Reproducing that locally requires installing `protoc` (the workflow pins a version via `PROTOC_VERSION`).
+
+## Further reading
+
+- [Repository overview](../README.md)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/starkware-libs/starknet-specs.git"
   },
   "scripts": {
-    "validate_all": "find api/ -name '*.json' -not -name 'starknet_metadata.json' | xargs -n1 node validate.js",
+    "validate_all": "find api/ -name '*.json' -not -name 'starknet_metadata.json' | xargs -n1 node validate.js && node validate.js wallet-api/wallet_rpc.json && node validate.js proving-api/starknet_proving_api_openrpc.json",
     "check_component_uniqueness": "node check_component_uniqueness.js",
     "format": "prettier --write --config .prettierrc .",
     "format_check": "prettier -c --config .prettierrc ."

--- a/proving-api/README.md
+++ b/proving-api/README.md
@@ -1,0 +1,26 @@
+# Starknet proving API (`proving-api/`)
+
+This directory defines the **Starknet transaction prover** JSON-RPC: how clients request proofs for transactions on top of a given block, separate from the public full-node read/write surface in `../api/`.
+
+## Files
+
+| File                                | Role                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `starknet_proving_api_openrpc.json` | OpenRPC document for the proving API (e.g. `starknet_proveTransaction`, `starknet_specVersion`). |
+
+External schema and error references use `./api/starknet_api_openrpc.json`, resolved from the **repository root** when running `validate.js` (same convention as `wallet-api/wallet_rpc.json`).
+
+## Validation
+
+From the repository root:
+
+```bash
+./validate.js proving-api/starknet_proving_api_openrpc.json
+```
+
+This file is included in `npm run validate_all`.
+
+## Further reading
+
+- [Node JSON-RPC](../api/README.md)
+- [Repository overview](../README.md)

--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -57,7 +57,7 @@
       },
       "errors": [
         {
-          "$ref": "../api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
         },
         {
           "$ref": "#/components/errors/ACCOUNT_VALIDATION_FAILED"
@@ -80,19 +80,19 @@
   "components": {
     "schemas": {
       "BLOCK_ID": {
-        "$ref": "../api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
       },
       "BROADCASTED_INVOKE_TXN": {
-        "$ref": "../api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_INVOKE_TXN"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_INVOKE_TXN"
       },
       "PROOF": {
-        "$ref": "../api/starknet_api_openrpc.json#/components/schemas/PROOF"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/PROOF"
       },
       "PROOF_FACTS": {
-        "$ref": "../api/starknet_api_openrpc.json#/components/schemas/PROOF_FACTS"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/PROOF_FACTS"
       },
       "MSG_TO_L1": {
-        "$ref": "../api/starknet_api_openrpc.json#/components/schemas/MSG_TO_L1"
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/MSG_TO_L1"
       },
       "PROVE_TRANSACTION_RESULT": {
         "title": "Prove transaction result",

--- a/wallet-api/README.md
+++ b/wallet-api/README.md
@@ -1,0 +1,25 @@
+# Starknet wallet API (`wallet-api/`)
+
+This directory defines the **Starknet wallet JSON-RPC** used between dapps and an injected wallet provider. It complements the full-node JSON-RPC in `../api/`: wallets handle consent, signing, and network selection and often proxy chain reads to an RPC endpoint.
+
+## Files
+
+| File              | Role                                                                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `wallet_rpc.json` | OpenRPC document for wallet methods (capabilities, accounts, chain switching, typed data signing, invoke/declare and related flows, etc.). |
+
+Wallet methods use the `wallet_` prefix (for example `wallet_requestAccounts`, `wallet_addInvokeTransaction`). Shared types may reference schemas under `../api/`.
+
+## Validation
+
+From the repository root:
+
+```bash
+./validate.js wallet-api/wallet_rpc.json
+```
+
+This file is also included in `npm run validate_all` (see [../api/README.md](../api/README.md)).
+
+## Further reading
+
+- [Repository overview](../README.md)

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1245,8 +1245,7 @@
       },
       "USER_REFUSED_OP": {
         "code": 113,
-        "message": "An error occurred (USER_REFUSED_OP)",
-        "description": "The user refused the operation in the wallet"
+        "message": "An error occurred (USER_REFUSED_OP): The user refused the operation in the wallet"
       },
       "INVALID_REQUEST_PAYLOAD": {
         "code": 114,
@@ -1258,28 +1257,23 @@
       },
       "DEPLOYMENT_DATA_NOT_AVAILABLE": {
         "code": 116,
-        "message": "An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE)",
-        "description": "The deployment data is not available or no supported"
+        "message": "An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE): The deployment data is not available or not supported"
       },
       "CHAIN_ID_NOT_SUPPORTED": {
         "code": 117,
-        "message": "An error occurred (CHAIN_ID_NOT_SUPPORTED)",
-        "description": "The requested chain ID is not supported by the wallet"
+        "message": "An error occurred (CHAIN_ID_NOT_SUPPORTED): The requested chain ID is not supported by the wallet"
       },
       "NOT_REGISTERED": {
         "code": 118,
-        "message": "An error occurred (NOT_REGISTERED)",
-        "description": "The user is not registered in the STRK20 privacy pool"
+        "message": "An error occurred (NOT_REGISTERED): The user is not registered in the STRK20 privacy pool"
       },
       "INSUFFICIENT_PRIVATE_BALANCE": {
         "code": 119,
-        "message": "An error occurred (INSUFFICIENT_PRIVATE_BALANCE)",
-        "description": "The user does not have enough private balance to cover the requested withdraw or transfer"
+        "message": "An error occurred (INSUFFICIENT_PRIVATE_BALANCE): The user does not have enough private balance to cover the requested withdraw or transfer"
       },
       "PRIVACY_LEAK": {
         "code": 120,
-        "message": "An error occurred (PRIVACY_LEAK)",
-        "description": "The wallet detected that completing the operation may compromise the user's privacy"
+        "message": "An error occurred (PRIVACY_LEAK): The wallet detected that completing the operation may compromise the user's privacy"
       },
       "API_VERSION_NOT_SUPPORTED": {
         "code": 162,

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1269,7 +1269,7 @@
       },
       "INSUFFICIENT_PRIVATE_BALANCE": {
         "code": 119,
-        "message": "An error occurred (INSUFFICIENT_PRIVATE_BALANCE): The user does not have enough private balance to cover the requested withdraw or transfer"
+        "message": "An error occurred (INSUFFICIENT_PRIVATE_BALANCE): The user does not have enough private balance to cover the requested withdrawal or transfer"
       },
       "PRIVACY_LEAK": {
         "code": 120,


### PR DESCRIPTION
## Changes

- Add focused README files under `api/`, `wallet-api/`, `proving-api/`, and `p2p/` describing each spec area, validation, and how pieces relate.
- Refresh the root `README.md` to index those areas and document Node.js tooling (`npm ci`, `npm run validate_all`, `check_component_uniqueness`, `format_check`).
- Extend `npm run validate_all` to validate wallet and proving OpenRPC documents alongside `api/` (excluding `starknet_metadata.json` as before).
- Fix `wallet-api/wallet_rpc.json` error components so they conform to the OpenRPC meta-schema (remove unsupported `description` on error objects; fold text into `message`).
- Fix `proving-api/starknet_proving_api_openrpc.json` external `$ref` paths to `./api/starknet_api_openrpc.json` so `validate.js` resolves from the repo root.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)

## Test plan

- [x] `npm ci`
- [x] `npm run validate_all`
- [x] `npm run check_component_uniqueness`
- [x] `npm run format_check`
- [x] `./validate.js api/starknet_api_openrpc.json`
- [x] `./validate.js wallet-api/wallet_rpc.json`
- [x] `./validate.js proving-api/starknet_proving_api_openrpc.json`
- [x] `find p2p -name '*.proto' | sort`

Made with [Cursor](https://cursor.com)