### PR TITLE
chore: migrate Starknet docs URLs to new paths

### DIFF
--- a/p2p/proto/sync/header.proto
+++ b/p2p/proto/sync/header.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/hea
 // Note: commitments may change to be for the previous blocks like comet/tendermint
 // hash of block header sent to L1
 message SignedBlockHeader {
-    Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash
+    Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/learn/protocol/blocks#block-hash
     Hash parent_hash = 2;
     uint64 number = 3; // This can be deduced from context. We can consider removing this field.
     uint64 time = 4; // Encoded in Unix time.

--- a/p2p/proto/sync/protocols.md
+++ b/p2p/proto/sync/protocols.md
@@ -178,7 +178,7 @@ Each single message is either a fin, or a [TransactionWithReceipt](./transaction
 (A pair of [TransactionInBlock](./transaction.proto) and [Receipt](./receipt.proto))
 
 Each transaction represents a Starknet transaction that's already part of the Starknet chain.
-For more detail on the different transaction types, their content and their hash calculation see [here](https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/).
+For more detail on the different transaction types, their content and their hash calculation see [here](https://docs.starknet.io/learn/protocol/transactions).
 
 The main differences between [TransactionInBlock](./transaction.proto) and a transaction that is pending insertion ([ConsensusTransaction](../consensus/consensus.proto) or [MempoolTransaction](../mempool/transaction.proto))
 are:
@@ -294,7 +294,7 @@ The classes protocol is used to download the classes declared in a range of bloc
 Its name for negotiation is `/starknet/classes/0.1.0-rc.0`
 
 Each single message is a fin or a [Class](../class.proto). For more information on classes, see
-[here](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-classes/)
+[here](https://docs.starknet.io/learn/protocol/state#the-class-trie)
 
 You should use the [state diff protocol](#state-diff) before using this protocol.
 The reason is that the class hashes and amount of declared classes per block are part of the


### PR DESCRIPTION
Update documentation links per docs.starknet.io site restructure.

## Changes

 <!-- Summarize how this PR improves the repository and mention resolvable issues, if any. -->

## Checklist:

- [ ] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [ ] Performed code self-review
- [ ] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)
