### PR TITLE
feat(wallet-api): allow OPEN literal for STRK20_TRANSFER_ACTION amount

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1103,8 +1103,16 @@
           },
           "amount": {
             "title": "Amount",
-            "description": "Amount of the token, in its smallest unit",
-            "$ref": "#/components/schemas/FELT"
+            "description": "Amount of the token, in its smallest unit, or the literal string \"OPEN\" to transfer the full opened note balance",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FELT"
+              },
+              {
+                "type": "string",
+                "enum": ["OPEN"]
+              }
+            ]
           },
           "recipient": {
             "title": "Recipient Address",


### PR DESCRIPTION
Allow the STRK20_TRANSFER_ACTION 'amount' field to be either a FELT or the literal string "OPEN" (transfer full opened note balance).