### PR TITLE
feat(proving-api): add opaque additional_data to proveTransaction result

### DIFF
--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -113,9 +113,18 @@
             "items": {
               "$ref": "#/components/schemas/MSG_TO_L1"
             }
+          },
+          "additional_data": {
+            "title": "Additional data",
+            "$ref": "#/components/schemas/ADDITIONAL_DATA"
           }
         },
         "required": ["proof", "proof_facts", "l2_to_l1_messages"]
+      },
+      "ADDITIONAL_DATA": {
+        "title": "Additional data",
+        "description": "Opaque side-channel attached alongside the proof and relayed verbatim by the prover from the external blocking check service. Optional; omitted from the response when absent. The prover does not interpret its contents — concrete keys (e.g. a screening signature under `signature`) are defined by the producing service, not by this API.",
+        "type": "object"
       }
     },
     "errors": {


### PR DESCRIPTION
## What

Documents the optional `additional_data` object on the `starknet_proveTransaction` result. The transaction prover relays it **verbatim** from the external screening service and does not interpret its contents.

Added to `proving-api/starknet_proving_api_openrpc.json`:
- `additional_data` — optional property on `PROVE_TRANSACTION_RESULT` (not in `required`).
- `ADDITIONAL_DATA` schema — an **open object** (`type: object`, no fixed properties, `additionalProperties` default true). Concrete keys (e.g. a screening signature under `signature`) are defined by the producing service, not by this API.

## Why

The prover ([starkware-libs/sequencer#14411](https://github.com/starkware-libs/sequencer/pull/14411)) is agnostic to `additional_data` — it carries an opaque object end-to-end. Pinning a typed `signature`/felt schema here would wrongly couple the prover's API to the screening domain, so the field is documented as an opaque pass-through. The result schema already had no `additionalProperties: false`, so emitting the field never violated the spec; this makes it self-describing.

## Backward compatibility

Fully backward-compatible: `additional_data` is optional, so existing responses without it validate unchanged.

## Validation

- OpenRPC doc parses; `prettier -c` passes.
- Validated `PROVE_TRANSACTION_RESULT` (cross-file refs registered as in the sequencer's spec test) against representative responses: no `additional_data` ✓, a `signature` object ✓, arbitrary future keys ✓, empty `{}` ✓; and a non-object `additional_data` is correctly rejected.

## Follow-up

Maintainers may want a version bump in `info.version` (left at `0.10.3-rc.0`) per the repo's dedicated-bump convention. Downstream, the sequencer crate's `starknet_specs_rev.txt` should be bumped to a commit including this change once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)