### PR TITLE
docs: remove stale RPC version from MCP setup

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,13 +1,13 @@
 # Starknet MCP Server
 
-An MCP (Model Context Protocol) server that exposes all Starknet JSON-RPC v0.10.2 methods as Claude Code tools. Lets Claude read blocks, transactions, state, traces, and more directly from a live Starknet node.
+An MCP (Model Context Protocol) server that exposes the Starknet JSON-RPC methods defined in this repository as Claude Code tools. Lets Claude read blocks, transactions, state, traces, and more directly from a live Starknet node.
 
 ## Installation
 
 ### Prerequisites
 
 - Python 3.10+
-- A Starknet JSON-RPC endpoint URL (any node implementing spec v0.10.2+)
+- A compatible Starknet JSON-RPC endpoint URL
 
 ### Using Claude Code (recommended)
 
@@ -41,7 +41,7 @@ claude mcp add --env STARKNET_RPC_URL=<your-rpc-url> starknet -- python mcp/serv
 claude mcp add --scope user --env STARKNET_RPC_URL=<your-rpc-url> starknet -- python /absolute/path/to/mcp/server.py
 ```
 
-Replace `<your-rpc-url>` with your Starknet JSON-RPC endpoint (v0.10.2+).
+Replace `<your-rpc-url>` with your Starknet JSON-RPC endpoint.
 
 3. Restart Claude Code for the server to take effect.
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Starknet RPC MCP Server — exposes all Starknet RPC v0.10.2 methods as Claude tools.
+"""Starknet RPC MCP Server — exposes Starknet RPC methods as Claude tools.
 
 Requires STARKNET_RPC_URL environment variable to be set to a Starknet JSON-RPC endpoint
-running spec version 0.10.2 or later.
+compatible with the methods exposed by this server.
 The URL can also be changed mid-conversation with the set_network / get_network tools.
 """
 
@@ -17,7 +17,7 @@ from mcp.server.fastmcp import FastMCP
 _initial_url = os.getenv("STARKNET_RPC_URL")
 if not _initial_url:
     print("Error: STARKNET_RPC_URL environment variable is required.", file=sys.stderr)
-    print("Set it to a Starknet JSON-RPC endpoint (spec v0.10.2+).", file=sys.stderr)
+    print("Set it to a compatible Starknet JSON-RPC endpoint.", file=sys.stderr)
     sys.exit(1)
 
 state = {"url": _initial_url}


### PR DESCRIPTION
## Changes

 <!-- Summarize how this PR improves the repository and mention resolvable issues, if any. -->

Update the MCP README and server startup hint to avoid referencing the stale `v0.10.2` JSON-RPC spec version.

The repository currently tracks newer RPC specs, while the MCP server exposes the Starknet RPC methods defined here. Referring to a hard-coded older version can make the setup instructions look outdated even when the server method coverage is current.



## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [ ] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)
