### PR TITLE
bump(wallet-api): set spec version to 0.10.3

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.0",
+    "version": "0.10.3",
     "title": "Starknet Wallet API",
     "license": {}
   },


### PR DESCRIPTION
## Changes

Bump the Starknet Wallet API spec version from `0.8.0` to `0.10.3`.

The `info.version` field in `wallet-api/wallet_rpc.json` was still pinned to `0.8.0`, lagging behind the current `0.10.3` release line (matching the repo's `package.json` and the recent `bump: v0.10.3-rc.*` tags). This is the only occurrence of the version string in the wallet spec; no schema/structural changes.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)
