### PR TITLE
feat(wallet-api): full semver in version schemas, bump spec to 0.10.3-rc.2

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.8.0",
+    "version": "0.10.3-rc.2",
     "title": "Starknet Wallet API",
     "license": {}
   },
@@ -14,7 +14,7 @@
       "params": [],
       "result": {
         "name": "result",
-        "description": "Semver of the wallet api versions supported by the wallet",
+        "description": "The full semver of the latest wallet API version supported by the wallet, and any past supported versions.",
         "required": true,
         "schema": {
           "type": "array",
@@ -700,15 +700,15 @@
       },
       "SPEC_VERSION": {
         "title": "Starknet Spec Version",
-        "description": "A Starknet RPC spec version, only two numbers are provided",
+        "description": "A Starknet JSON-RPC spec version, following semantic versioning.",
         "type": "string",
-        "pattern": "^[0-9]+\\.[0-9]+$"
+        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$"
       },
       "API_VERSION": {
         "title": "Wallet API version",
-        "description": "The version of wallet API expected by the request. If not specified, the latest is assumed",
+        "description": "A wallet API version, following semantic versioning. When used as a request parameter and not specified, the latest is assumed.",
         "type": "string",
-        "pattern": "^[0-9]+\\.[0-9]+$"
+        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$"
       },
       "PERMISSION": {
         "title": "Wallet permission",


### PR DESCRIPTION
## Changes

Aligns how the wallet API reports its version with how full nodes report theirs
(`starknet_specVersion` returns the full version, e.g. `0.10.3-rc.2`).

- **`wallet_supportedWalletApi`** now returns the full semver of the latest
  supported wallet API version plus any past compatible versions
  (e.g. `["0.10.3-rc2", "0.7.2"]`), instead of a single `MAJOR.MINOR` value.
- **`API_VERSION` / `SPEC_VERSION`** patterns widened from `^[0-9]+\.[0-9]+$`
  to full semver with optional patch + pre-release:
  `^[0-9]+\.[0-9]+(\.[0-9]+(-[0-9A-Za-z.-]+)?)?$`. The legacy `MAJOR.MINOR`
  form (e.g. `0.7`) is still accepted for backward compatibility. Both schemas
  share one pattern, so `api_version`, `wallet_supportedSpecs`, and
  `wallet_supportedWalletApi` stay consistent.
- **`info.version`** bumped `0.8.0` -> `0.10.3-rc.2` to match the RPC specs
  (the wallet spec is skipped by the repo-wide version bump, so it had drifted).

## Checklist:

- [x] Validated the specification files - `npm run validate_all` *(covers `api/` only; wallet spec verified via `npm run format_check`)*
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] Checked if this PR resolves any issues
- [ ] If making a new release, check out the guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
