### PR TITLE
fix(wallet-api): disallow prerelease in API_VERSION pattern

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -708,7 +708,7 @@
         "title": "Wallet API version",
         "description": "A wallet API version, following semantic versioning. When used as a request parameter and not specified, the latest is assumed.",
         "type": "string",
-        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$"
+        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
       },
       "PERMISSION": {
         "title": "Wallet permission",


### PR DESCRIPTION
## What

Restrict the wallet `API_VERSION` schema pattern to match only `X.Y` or `X.Y.Z` (e.g. `0.10`, `0.10.2`), rejecting prerelease/build suffixes such as `0.10.2-rc.2`.

```diff
-        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$"
+        "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
```

## Why

[#396](https://github.com/starkware-libs/starknet-specs/pull/396) widened both `API_VERSION` and `SPEC_VERSION` to full semver, which also permits prerelease suffixes (`-rc.2`, etc.). The wallet API version should be a stable `X.Y` / `X.Y.Z` identifier and not carry prerelease tags.

## Scope

- **Only `API_VERSION` is changed.**
- `SPEC_VERSION` is intentionally left unchanged, since it mirrors `starknet_specVersion`, which may legitimately report prerelease versions (e.g. `0.10.3-rc.2`).

The updated pattern accepts `0.10`, `0.10.2`, `1.0.0` and rejects `0.10.2-rc.2`, `0`, `0.10.`, `0.1.2.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
