### PR TITLE
bump: v0.10.3-rc.3

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.3-rc.2",
+  "version": "0.10.3-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet_specs",
-      "version": "0.10.3-rc.2",
+      "version": "0.10.3-rc.3",
       "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.3-rc.2",
+  "version": "0.10.3-rc.3",
   "description": "Tooling for OpenRPC files",
   "repository": {
     "type": "git",

--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "Starknet Transaction Prover API",
     "description": "JSON-RPC API for proving Starknet transactions via the Starknet Transaction Prover.",
     "license": {

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.3-rc.2",
+    "version": "0.10.3-rc.3",
     "title": "Starknet Wallet API",
     "license": {}
   },


### PR DESCRIPTION
Bump spec version `0.10.3-rc.2` → `0.10.3-rc.3`.

Version updated in all version-bearing files:
- `api/starknet_api_openrpc.json`, `starknet_executables.json`, `starknet_metadata.json`, `starknet_trace_api_openrpc.json`, `starknet_write_api.json`, `starknet_ws_api.json`
- `proving-api/starknet_proving_api_openrpc.json`
- `package.json`, `package-lock.json`
- `wallet-api/wallet_rpc.json`



🤖 Generated with [Claude Code](https://claude.com/claude-code)
