### PR TITLE
docs: document per-spec release scope and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,31 @@
 
 This repository publishes different technical specifications pertaining to the implementation and interaction with Starknet.
 
-## API
+## Specifications
 
-The JSON-RPC API can be found under the `api/` folder.
-You can view it more conveniently using the OpenRPC playground [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false).
+| Spec                                       | Folder         | Version advertised by        |
+| ------------------------------------------ | -------------- | ---------------------------- |
+| [Full node JSON-RPC](./api/)               | `api/`         | `starknet_specVersion`       |
+| [Wallet API](./wallet-api/wallet_rpc.json) | `wallet-api/`  | `wallet_supportedWalletApi`  |
+| [Proving API](./proving-api/)              | `proving-api/` | the proving API version call |
+| [P2P](./p2p/README.md)                     | `p2p/`         | –                            |
 
-A guide to the API can be found [here](./starknet_vs_ethereum_node_apis.md).
+The full node JSON-RPC API can be viewed in the OpenRPC playground [here](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false), and a guide to it is [here](./starknet_vs_ethereum_node_apis.md).
+
+## Versioning and Releases
+
+All files share one version number, but each release changes only one of the specs above. An implementation advertises the version of the latest release that changed its spec, so implementations may correctly report different versions.
+
+This applies from `v0.10.4` onward. Earlier releases predate it and may have changed more than one spec.
+
+The latest release that changed each spec:
+
+| Spec               | Current version |
+| ------------------ | --------------- |
+| Full node JSON-RPC | `0.10.2`        |
+| Wallet API         | `0.10.4-rc.0`   |
+| Proving API        | `0.10.3`        |
+| P2P                | `0.10.3`        |
 
 ## MCP Server (Claude Code)
 

--- a/api/release.md
+++ b/api/release.md
@@ -47,6 +47,14 @@ When updating the specification version, change the `"version"` property in all 
 npm version <VERSION> --no-git-tag-version
 ```
 
+## Release Scope
+
+Each release changes exactly one of the specifications in this repository (see the
+[README](../README.md#specifications)). Release notes state at the top which one, so
+readers can tell whether a release concerns them without reading the changelog.
+
+An implementation bumps the version it advertises only when a release changes the spec it implements.
+
 ## Technical Implementation
 
 We use github releases on this repo to publish releases.

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -9,11 +9,12 @@
   "methods": [
     {
       "name": "starknet_specVersion",
-      "summary": "Returns the version of the Starknet JSON-RPC specification being used",
+      "summary": "Returns the version of the Starknet JSON-RPC specification implemented by this node",
+      "description": "Returns the version of the full node JSON-RPC specification that this node implements. This is the version of the most recent specification release that changed the full node JSON-RPC API.",
       "params": [],
       "result": {
         "name": "result",
-        "description": "Semver of Starknet's JSON-RPC spec being used",
+        "description": "Semver of the full node JSON-RPC spec implemented by this node",
         "required": true,
         "schema": {
           "title": "JSON-RPC spec version",

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -10,7 +10,7 @@
     {
       "name": "starknet_specVersion",
       "summary": "Returns the version of the Starknet JSON-RPC specification implemented by this node",
-      "description": "Returns the version of the full node JSON-RPC specification that this node implements. This is the version of the most recent specification release that changed the full node JSON-RPC API.",
+      "description": "Returns the version of the full node JSON-RPC specification that this node implements. This is the version of the most recent specification release that changed the full node JSON-RPC API in a way that required changes to the node implementation. Changes that are transparent to the node implementation do not affect the reported version.",
       "params": [],
       "result": {
         "name": "result",

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -10,7 +10,7 @@
     {
       "name": "wallet_supportedWalletApi",
       "summary": "Returns a list of wallet api versions compatible with the wallet. Notice this might be different from Starknet JSON-RPC spec",
-      "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values.",
+      "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values. The versions returned refers to latest Wallet API releases.",
       "params": [],
       "result": {
         "name": "result",
@@ -29,11 +29,11 @@
     {
       "name": "wallet_supportedSpecs",
       "summary": "Returns a list of rpc spec versions compatible with the wallet",
-      "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values.",
+      "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values. These are full node JSON-RPC spec versions, and are distinct from the Wallet API versions returned by `wallet_supportedWalletApi`.",
       "params": [],
       "result": {
         "name": "result",
-        "description": "Semver of Starknet's JSON-RPC supported by the wallet",
+        "description": "Semver of Starknet's JSON-RPC supported by the wallet.",
         "required": true,
         "schema": {
           "type": "array",


### PR DESCRIPTION
## Changes

**The problem.** All specs here share one version number, but a release usually changes only one of them. `0.10.3` and `0.10.4` changed only the wallet API, yet appeared to supersede the `0.10.2` that up-to-date full nodes correctly report — so a load-balanced RPC serving both Pathfinder and Juno returned different spec versions, and consumers read the lower one as out of date.

**What this documents:**

- `README.md` — which specs this repo publishes, which call advertises each, and the version each is currently at.
- `api/release.md` — a Release Scope section: each release changes exactly one spec, release notes state which one, and an implementation bumps the version it advertises only when a release changes the spec it implements. Applies from `v0.10.4` onward.
- `starknet_specVersion`, `wallet_supportedWalletApi`, `wallet_supportedSpecs` — the same distinction stated where implementers actually read it, rather than only in the release-process doc.

Editorial only — no schema, type, or wire format changes, so no version bump. Same category as the `PROOF`/`PROOF_FACTS` extraction in `0.10.3`.


## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [ ] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)