### PR TITLE
wallet-api: rename STRK20 sub-accounts to shadow accounts

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -634,13 +634,13 @@
       ]
     },
     {
-      "name": "wallet_strk20SubaccountCommitment",
-      "summary": "Compute the commitment for a dapp's STRK20 sub-accounts",
-      "description": "Returns a STRK20 sub-account commitment, computed locally by the wallet from the user's private state (no transaction is sent). When 'nonce' is given, returns the full commitment for that single sub-account: hash(partial_commitment, nonce); each nonce maps to a distinct, deterministic sub-account for the user + dapp. When 'nonce' is omitted, returns the partial (nonce-independent) commitment: hash(identity_key, dapp_name), where identity_key is derived from the user, their viewing key, and the sub-account anonymizer address. The partial commitment is shared by every sub-account the user derives for this dapp, so it can be published once to let a dapp recognize all of the user's sub-accounts without learning any individual nonce. If the user is not registered in the STRK20 privacy pool, NOT_REGISTERED is returned.",
+      "name": "wallet_strk20ShadowAccountCommitment",
+      "summary": "Compute the commitment for a dapp's STRK20 shadow accounts",
+      "description": "Returns a STRK20 shadow account commitment, computed locally by the wallet from the user's private state (no transaction is sent). When 'nonce' is given, returns the full commitment for that single shadow account: hash(partial_commitment, nonce); each nonce maps to a distinct, deterministic shadow account for the user + dapp. When 'nonce' is omitted, returns the partial (nonce-independent) commitment: hash(identity_key, dapp_name), where identity_key is derived from the user, their viewing key, and the shadow account anonymizer address. The partial commitment is shared by every shadow account the user derives for this dapp, so it can be published once to let a dapp recognize all of the user's shadow accounts without learning any individual nonce. If the user is not registered in the STRK20 privacy pool, NOT_REGISTERED is returned.",
       "params": [
         {
           "name": "dapp_name",
-          "description": "The dapp that scopes the sub-account(s)",
+          "description": "The dapp that scopes the shadow account(s)",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/STRK20_DAPP_NAME"
@@ -648,7 +648,7 @@
         },
         {
           "name": "nonce",
-          "description": "The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp. When omitted, the partial (nonce-independent) commitment shared by all of the dapp's sub-accounts is returned instead.",
+          "description": "The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp. When omitted, the partial (nonce-independent) commitment shared by all of the dapp's shadow accounts is returned instead.",
           "required": false,
           "schema": {
             "$ref": "#/components/schemas/FELT"
@@ -664,10 +664,10 @@
       ],
       "result": {
         "name": "result",
-        "description": "The sub-account commitment: hash(partial_commitment, nonce) when 'nonce' was given, otherwise the partial commitment hash(identity_key, dapp_name)",
+        "description": "The shadow account commitment: hash(partial_commitment, nonce) when 'nonce' was given, otherwise the partial commitment hash(identity_key, dapp_name)",
         "required": true,
         "schema": {
-          "title": "Sub-account Commitment",
+          "title": "Shadow Account Commitment",
           "$ref": "#/components/schemas/FELT"
         }
       },
@@ -1095,7 +1095,7 @@
             "$ref": "#/components/schemas/STRK20_INVOKE_ACTION"
           },
           {
-            "$ref": "#/components/schemas/STRK20_SUBACCOUNT_INVOKE_ACTION"
+            "$ref": "#/components/schemas/STRK20_SHADOW_ACCOUNT_INVOKE_ACTION"
           }
         ]
       },
@@ -1221,29 +1221,29 @@
         "type": "string",
         "pattern": "^\\$\\{(?:openNoteIds\\[[0-9]+\\]|poolAddress)\\}$"
       },
-      "STRK20_SUBACCOUNT_INVOKE_ACTION": {
-        "title": "STRK20 Sub-account Invoke Action",
-        "description": "Invokes one or more contract calls through the user's STRK20 sub-account for a dapp, routed via the sub-account anonymizer. The sub-account is selected by (dapp_name, nonce); each nonce maps to a distinct, deterministic sub-account. The proceeds of the calls are settled into the open notes created by transfer actions with amount \"OPEN\" in the same transaction, so the usual rule applies: the number of open notes filled by this action must match the number of open notes created in the transaction.",
+      "STRK20_SHADOW_ACCOUNT_INVOKE_ACTION": {
+        "title": "STRK20 Shadow Account Invoke Action",
+        "description": "Invokes one or more contract calls through the user's STRK20 shadow account for a dapp, routed via the shadow account anonymizer. The shadow account is selected by (dapp_name, nonce); each nonce maps to a distinct, deterministic shadow account. The proceeds of the calls are settled into the open notes created by transfer actions with amount \"OPEN\" in the same transaction, so the usual rule applies: the number of open notes filled by this action must match the number of open notes created in the transaction.",
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["subaccount_invoke"]
+            "enum": ["shadow_account_invoke"]
           },
           "dapp_name": {
             "title": "Dapp Name",
-            "description": "The dapp that scopes the sub-account",
+            "description": "The dapp that scopes the shadow account",
             "$ref": "#/components/schemas/STRK20_DAPP_NAME"
           },
           "nonce": {
-            "title": "Sub-account Nonce",
-            "description": "The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp",
+            "title": "Shadow Account Nonce",
+            "description": "The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp",
             "$ref": "#/components/schemas/FELT"
           },
           "calls": {
             "type": "array",
             "title": "Calls",
-            "description": "The contract calls to execute through the sub-account, in order",
+            "description": "The contract calls to execute through the shadow account, in order",
             "items": {
               "$ref": "#/components/schemas/INVOKE_CALL"
             },
@@ -1251,7 +1251,7 @@
           },
           "collect_policy": {
             "title": "Collect Policy",
-            "description": "A single policy applied to every open note this action settles: how much of the sub-account's balance each note collects.",
+            "description": "A single policy applied to every open note this action settles: how much of the shadow account's balance each note collects.",
             "$ref": "#/components/schemas/STRK20_COLLECT_POLICY"
           }
         },
@@ -1259,7 +1259,7 @@
       },
       "STRK20_COLLECT_POLICY": {
         "title": "STRK20 Collect Policy",
-        "description": "How much of the sub-account's token balance a settled open note collects. 'all' collects the sub-account's entire token balance; 'diff' collects only the balance gained during this interaction; 'exact' collects the given amount (which must be provided).",
+        "description": "How much of the shadow account's token balance a settled open note collects. 'all' collects the shadow account's entire token balance; 'diff' collects only the balance gained during this interaction; 'exact' collects the given amount (which must be provided).",
         "type": "object",
         "properties": {
           "type": {
@@ -1276,7 +1276,7 @@
       },
       "STRK20_DAPP_NAME": {
         "title": "STRK20 Dapp Name",
-        "description": "Identifies the dapp that scopes a set of STRK20 sub-accounts, as a single felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most 31 characters that the wallet encodes as a Cairo short string.",
+        "description": "Identifies the dapp that scopes a set of STRK20 shadow accounts, as a single felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most 31 characters that the wallet encodes as a Cairo short string.",
         "type": "string"
       },
       "STRK20_BALANCE_ENTRY": {


### PR DESCRIPTION
## Description

Renames the STRK20 sub-account concept to **shadow account** across the wallet API spec. Terminology only — no semantic or structural change.

### Breaking (wire-visible)

| Before | After |
|---|---|
| `wallet_strk20SubaccountCommitment` | `wallet_strk20ShadowAccountCommitment` |
| `STRK20_SUBACCOUNT_INVOKE_ACTION` | `STRK20_SHADOW_ACCOUNT_INVOKE_ACTION` |
| `"subaccount_invoke"` (action discriminator) | `"shadow_account_invoke"` |

The remaining 16 changed lines are summaries, descriptions and titles.

## Checklist:

- [x] Validated the specification files - `npm run validate_all`
- [x] Applied formatting - `npm run format`
- [x] Performed code self-review
- [x] Checked if this PR resolves any [issues](https://github.com/starkware-libs/starknet-specs/issues)
- [ ] If making a new release, check out [the guidelines](https://github.com/starkware-libs/starknet-specs/blob/master/api/release.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)