### PR TITLE
bump: v0.10.4-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The latest release that changed each spec:
 | Spec               | Current version |
 | ------------------ | --------------- |
 | Full node JSON-RPC | `0.10.2`        |
-| Wallet API         | `0.10.4-rc.0`   |
+| Wallet API         | `0.10.4-rc.1`   |
 | Proving API        | `0.10.3`        |
 | P2P                | `0.10.3`        |
 

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.0",
+  "version": "0.10.4-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet_specs",
-      "version": "0.10.4-rc.0",
+      "version": "0.10.4-rc.1",
       "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.0",
+  "version": "0.10.4-rc.1",
   "description": "Tooling for OpenRPC files",
   "repository": {
     "type": "git",

--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "Starknet Transaction Prover API",
     "description": "JSON-RPC API for proving Starknet transactions via the Starknet Transaction Prover.",
     "license": {

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.0",
+    "version": "0.10.4-rc.1",
     "title": "Starknet Wallet API",
     "license": {}
   },


### PR DESCRIPTION
Bumps the shared spec version from `0.10.4-rc.0` to `0.10.4-rc.1`.

**Release scope: Wallet API.**

Since `v0.10.4-rc.0`, the only spec change was the rename of STRK20 sub-accounts to shadow accounts in `wallet-api/wallet_rpc.json` (33052e9). The full node JSON-RPC change in that range was editorial only — `starknet_specVersion` summary/description wording — so the full node version stays at `0.10.2`.

Changes:
- `"version"` bumped in all specification files (`api/`, `wallet-api/`, `proving-api/`)
- `package.json` / `package-lock.json` bumped via `npm version 0.10.4-rc.1 --no-git-tag-version`
- README version table: Wallet API row → `0.10.4-rc.1`

`npm run validate_all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)