### PR TITLE
feat: add optional valid_until to wallet_strk20Balances

### DIFF
--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -598,6 +598,17 @@
           }
         },
         {
+          "name": "valid_until",
+          "description": "Requested expiry of the balance-read authorization, as a Unix timestamp in seconds. When omitted, the wallet applies its own default window.",
+          "required": false,
+          "schema": {
+            "title": "Timestamp",
+            "description": "The time at which the authorization expires, encoded in Unix time",
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        {
           "name": "api_version",
           "required": false,
           "schema": {


### PR DESCRIPTION
Adds an optional `valid_until` param to `wallet_strk20Balances`, letting a dapp request how long its authorization to read shielded balances stays valid. A multi-step flow such as a swap can then re-query balances without prompting the user on each call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)