### PR TITLE
bump: v0.10.4-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The latest release that changed each spec:
 | Spec               | Current version |
 | ------------------ | --------------- |
 | Full node JSON-RPC | `0.10.2`        |
-| Wallet API         | `0.10.4-rc.1`   |
+| Wallet API         | `0.10.4-rc.2`   |
 | Proving API        | `0.10.3`        |
 | P2P                | `0.10.3`        |
 

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.1",
+  "version": "0.10.4-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet_specs",
-      "version": "0.10.4-rc.1",
+      "version": "0.10.4-rc.2",
       "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.1",
+  "version": "0.10.4-rc.2",
   "description": "Tooling for OpenRPC files",
   "repository": {
     "type": "git",

--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "Starknet Transaction Prover API",
     "description": "JSON-RPC API for proving Starknet transactions via the Starknet Transaction Prover.",
     "license": {

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.1",
+    "version": "0.10.4-rc.2",
     "title": "Starknet Wallet API",
     "license": {}
   },


### PR DESCRIPTION
Bumps the shared spec version from `0.10.4-rc.1` to `0.10.4-rc.2`.

**Release scope: Wallet API.**

Since `v0.10.4-rc.1`, the only spec change was the addition of the optional `valid_until` parameter to `wallet_strk20Balances` in `wallet-api/wallet_rpc.json` (9495f45, #408). No other spec was touched in that range, so the full node JSON-RPC, Proving API and P2P versions are unchanged.

Changes:
- `"version"` bumped in all specification files (`api/`, `wallet-api/`, `proving-api/`)
- `package.json` / `package-lock.json` bumped to `0.10.4-rc.2`
- README version table: Wallet API row → `0.10.4-rc.2`

`npm run validate_all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)