### PR TITLE
bump: v0.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The latest release that changed each spec:
 | Spec               | Current version |
 | ------------------ | --------------- |
 | Full node JSON-RPC | `0.10.2`        |
-| Wallet API         | `0.10.4-rc.2`   |
+| Wallet API         | `0.10.4`        |
 | Proving API        | `0.10.3`        |
 | P2P                | `0.10.3`        |
 

--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "StarkNet Node API",
     "license": {}
   },

--- a/api/starknet_executables.json
+++ b/api/starknet_executables.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "API for getting Starknet executables from nodes that store compiled artifacts",
     "license": {}
   },

--- a/api/starknet_metadata.json
+++ b/api/starknet_metadata.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "Starknet ABI specs"
   },
   "methods": [],

--- a/api/starknet_trace_api_openrpc.json
+++ b/api/starknet_trace_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "StarkNet Trace API",
     "license": {}
   },

--- a/api/starknet_write_api.json
+++ b/api/starknet_write_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "StarkNet Node Write API",
     "license": {}
   },

--- a/api/starknet_ws_api.json
+++ b/api/starknet_ws_api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "StarkNet WebSocket RPC API",
     "license": {}
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.2",
+  "version": "0.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet_specs",
-      "version": "0.10.4-rc.2",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet_specs",
-  "version": "0.10.4-rc.2",
+  "version": "0.10.4",
   "description": "Tooling for OpenRPC files",
   "repository": {
     "type": "git",

--- a/proving-api/starknet_proving_api_openrpc.json
+++ b/proving-api/starknet_proving_api_openrpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "Starknet Transaction Prover API",
     "description": "JSON-RPC API for proving Starknet transactions via the Starknet Transaction Prover.",
     "license": {

--- a/wallet-api/wallet_rpc.json
+++ b/wallet-api/wallet_rpc.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.0.0-rc1",
   "info": {
-    "version": "0.10.4-rc.2",
+    "version": "0.10.4",
     "title": "Starknet Wallet API",
     "license": {}
   },


### PR DESCRIPTION
Promotes `0.10.4-rc.2` to stable `0.10.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)